### PR TITLE
Make setup.py work with python 2.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ if not sys.version_info[0] == 2:
     print "Sorry, Python 3 is not supported (yet)"
     exit()
 
-if sys.version_info.major == 2 and sys.version_info.minor < 6:
+if sys.version_info[0] == 2 and sys.version_info[1] < 6:
     print "Sorry, Python < 2.6 is not supported"
     exit()
 


### PR DESCRIPTION
Python 2.6 doesn't have named components for sys.version_info.
