### PR TITLE
Fix LockContext to use device_handler

### DIFF
--- a/ncclient/manager.py
+++ b/ncclient/manager.py
@@ -187,7 +187,7 @@ class Manager(object):
             finally:
                 m.unlock("running")
         """
-        return operations.LockContext(self._session, target)
+        return operations.LockContext(self._session, target, self._device_handler)
 
     def scp(self):
         return self._session.scp()

--- a/ncclient/operations/lock.py
+++ b/ncclient/operations/lock.py
@@ -58,14 +58,15 @@ class LockContext(object):
     Initialise with (:class:`Session <ncclient.transport.Session>`) instance and lock target.
     """
 
-    def __init__(self, session, target):
+    def __init__(self, session, target, device_handler):
         self.session = session
         self.target = target
+        self.device_handler = device_handler
 
     def __enter__(self):
-        Lock(self.session, raise_mode=RaiseMode.ERRORS).request(self.target)
+        Lock(self.session, self.device_handler, raise_mode=RaiseMode.ERRORS).request(self.target)
         return self
 
     def __exit__(self, *args):
-        Unlock(self.session, raise_mode=RaiseMode.ERRORS).request(self.target)
+        Unlock(self.session, self.device_handler, raise_mode=RaiseMode.ERRORS).request(self.target)
         return False


### PR DESCRIPTION
LockContext was not using the new device_handler feature, making it
impossible to use the "with m.locked('candidate')" statement.
