### PR TITLE
update docs for Nexus device handler

### DIFF
--- a/README
+++ b/README
@@ -57,7 +57,7 @@ For example to invoke Juniper's functions annd params one has to re-write the ab
         with open("%s.xml" % host, 'w') as f:
             f.write(c)
 
-Respectively, for Cisco nxos, the name is **nxos**.
+Respectively, for Cisco Nexus, the name is **nexus**.
 Device handlers are easy to implement and prove to be futureproof.
 
 ### Changes | brief

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ For example to invoke Juniper's functions annd params one has to re-write the ab
         with open("%s.xml" % host, 'w') as f:
             f.write(c)
 
-Respectively, for Cisco nxos, the name is **nxos**.
+Respectively, for Cisco Nexus, the name is **nexus**.
 Device handlers are easy to implement and prove to be futureproof.
 
 ### Changes | brief

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -32,7 +32,7 @@ For example to invoke Juniper's functions annd params one has to re-write the ab
         with open("%s.xml" % host, 'w') as f:
             f.write(c)
 
-Respectively, for Cisco nxos, the name is **nxos**.
+Respectively, for Cisco Nexus, the name is **nexus**.
 Device handlers are easy to implement and prove to be futureproof.
 
 The latest pull request merge includes support for Huawei devices with name **huawei** in device_params.

--- a/ncclient/manager.py
+++ b/ncclient/manager.py
@@ -95,7 +95,7 @@ def connect_ssh(*args, **kwds):
 
     To invoke advanced vendor related operation add device_params =
         {'name':'<vendor_alias>'} in connection paramerers. For the time,
-        'junos' and 'nxos' are supported for Juniper and Cisco Nexus respectively.
+        'junos' and 'nexus' are supported for Juniper and Cisco Nexus respectively.
     """
     # Extract device parameter dict, if it was passed into this function. Need to
     # remove it from kwds, since the session.connect() doesn't like extra stuff in


### PR DESCRIPTION
The documentation currently refers to the device handler as 'nxos', but the handler's name is actually 'nexus'.
