### PR TITLE
Fix Juniper commit confirmed

### DIFF
--- a/ncclient/operations/third_party/juniper/rpc.py
+++ b/ncclient/operations/third_party/juniper/rpc.py
@@ -69,7 +69,7 @@ class Commit(RPC):
 
         *confirmed* whether this is a confirmed commit. Mutually exclusive with at_time.
 
-        *timeout* specifies the confirm timeout in seconds
+        *timeout* specifies the confirm timeout in minutes
 
         *comment* a string to comment the commit with. Review on the device using 'show system commit'
 

--- a/ncclient/operations/third_party/juniper/rpc.py
+++ b/ncclient/operations/third_party/juniper/rpc.py
@@ -78,7 +78,7 @@ class Commit(RPC):
         *at_time* Mutually exclusive with confirmed. The time at which the commit should happen. Junos expects either of these two formats:
             A time value of the form hh:mm[:ss] (hours, minutes, and, optionally, seconds)
             A date and time value of the form yyyy-mm-dd hh:mm[:ss] (year, month, date, hours, minutes, and, optionally, seconds)"""
-        node = new_ele("commit")
+        node = new_ele("commit-configuration")
         if confirmed and at_time is not None:
             raise NCClientError("'Commit confirmed' and 'commit at' are mutually exclusive.")
         if confirmed:


### PR DESCRIPTION
I had been working on implementing the new updates to NCClient into our module, when I noticed commit confirm operations were not acting as expected on Junos. While the commit would succeed, and the device would state that the commit would be rolled back after the timeout value, this isn't what would happen. The device would rollback the commit immediately, without waiting the specified timeout value. 

After much digging and looking back and referencing [this](http://www.juniper.net/documentation/en_US/junos13.3/topics/reference/tag-summary/netconf-junos-xml-protocol-commit-configuration.html) Juniper techpub article, I found that Junos actually expects the xml tree for a commit RPC to have `commit-configuration` as the top level node, not `commit`. 

After making this change, commit confirms work, (as well as the other juniper specific commit options, as I tested all of them). However, Junos now reads the timeout value as minutes, and not seconds with this new top-level node, as that techpub article states. 