### PR TITLE
encoding data otherwise getting exception ValueError

### DIFF
--- a/ncclient/xml_.py
+++ b/ncclient/xml_.py
@@ -121,7 +121,7 @@ def validated_element(x, tags=None, attrs=None):
 
     Raises :exc:`XMLError` if the requirements are not met.
     """
-    ele = to_ele(x)
+    ele = to_ele(x) if sys.version < '3' else to_ele(x.encode('UTF-8'))
     if tags:
         if isinstance(tags, (str, bytes)):
             tags = [tags]

--- a/ncclient/xml_.py
+++ b/ncclient/xml_.py
@@ -101,7 +101,10 @@ def to_xml(ele, encoding="UTF-8", pretty_print=False):
 
 def to_ele(x):
     "Convert and return the :class:`~xml.etree.ElementTree.Element` for the XML document *x*. If *x* is already an :class:`~xml.etree.ElementTree.Element` simply returns that."
-    return x if etree.iselement(x) else etree.fromstring(x, parser=parser)
+    if sys.version < '3':
+        return x if etree.iselement(x) else etree.fromstring(x, parser=parser)
+    else:
+        return x if etree.iselement(x) else etree.fromstring(x.encode('UTF-8'), parser=parser)
 
 def parse_root(raw):
     "Efficiently parses the root element of a *raw* XML document, returning a tuple of its qualified name and attribute dictionary."
@@ -121,7 +124,7 @@ def validated_element(x, tags=None, attrs=None):
 
     Raises :exc:`XMLError` if the requirements are not met.
     """
-    ele = to_ele(x) if sys.version < '3' else to_ele(x.encode('UTF-8'))
+    ele = to_ele(x)
     if tags:
         if isinstance(tags, (str, bytes)):
             tags = [tags]


### PR DESCRIPTION
Without encoded date python 3.x would break with:

ncclient/ncclient/xml_.py", line 104, in to_ele
    return x if etree.iselement(x) else etree.fromstring(x, parser=parser)
  File "src/lxml/lxml.etree.pyx", line 3213, in lxml.etree.fromstring (src/lxml/lxml.etree.c:82934)
  File "src/lxml/parser.pxi", line 1814, in lxml.etree._parseMemoryDocument (src/lxml/lxml.etree.c:124471)
ValueError: Unicode strings with encoding declaration are not supported. Please use bytes input or XML fragments without declaration.