### PR TITLE
Lower required lxml version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 setuptools>0.6
 paramiko>=1.7.7.1
-lxml>=3.3.0
+lxml>=3.1
 six


### PR DESCRIPTION
ncclient doesn't use any features of the newest lxml module.
So lower the requirement.

OpenStack Liberty has as requirement lxml>=2.3 and some networking
modules need ncclient. Requiring the same version reduces the
"dependency hell" for distributions when putting together all the
different python modules.
