### PR TITLE
strip \0 in response for huawei

### DIFF
--- a/ncclient/devices/huawei.py
+++ b/ncclient/devices/huawei.py
@@ -40,6 +40,9 @@ class HuaweiDeviceHandler(DefaultDeviceHandler):
         dict["action"] = Action
         return dict
 
+    def handle_raw_dispatch(self, raw):
+        return raw.strip('\0')
+
     def get_capabilities(self):
         # Just need to replace a single value in the default capabilities
         c = super(HuaweiDeviceHandler, self).get_capabilities()


### PR DESCRIPTION
@leopoul good suggestion, it works :)

Besides, it would be better if we can avoid the 'try ... except' block in _dispatch_message(),
for example, change the handle_raw_dispatch() in devices/default.py:

```python
def handle_raw_dispatch(self, raw):
    return raw
```