### PR TITLE
fix(third_party): huawei action operation keyword

### DIFF
--- a/ncclient/operations/third_party/huawei/rpc.py
+++ b/ncclient/operations/third_party/huawei/rpc.py
@@ -14,13 +14,14 @@ class CLI(RPC):
               Configuration system view exec
         """
         # node = new_ele("execute-cli")
-        node = new_ele('execute-cli', attrs={"xmlns":HW_PRIVATE_NS})
+        node = new_ele("execute-cli", attrs={"xmlns":HW_PRIVATE_NS})
         node.append(validated_element(command))
         return self._request(node)
 
 
 class Action(RPC):
+    "`execute-action` RPC"
     def request(self, action=None):
-        node = new_ele("action")
+        node = new_ele("execute-action", attrs={"xmlns":HW_PRIVATE_NS})
         node.append(validated_element(action))
         return self._request(node)


### PR DESCRIPTION
Fix two points for third party operation:
1. For huawei device, the action rpc's keyword is "execute-action".
2. For huawei private rpc operation, the namespace should use its private namespace string..