### PR TITLE
Fix receiving an incomplete delimiter in netconf ssh transport

### DIFF
--- a/ncclient/transport/ssh.py
+++ b/ncclient/transport/ssh.py
@@ -105,7 +105,7 @@ class SSHSession(Session):
 
         logger.debug("parsing netconf v1.0")
         delim = MSG_DELIM
-        n = len(delim) - 1
+        n = len(delim)
         expect = self._parsing_state10
         buf = self._buffer
         buf.seek(self._parsing_pos10)
@@ -138,12 +138,12 @@ class SSHSession(Session):
                 logger.debug('parsed new message')
                 if sys.version < '3':
                     self._dispatch_message(buf.read(msg_till).strip())
-                    buf.seek(n+1, os.SEEK_CUR)
+                    buf.seek(n, os.SEEK_CUR)
                     rest = buf.read()
                     buf = StringIO()
                 else:
                     self._dispatch_message(buf.read(msg_till).strip().decode('UTF-8'))
-                    buf.seek(n+1, os.SEEK_CUR)
+                    buf.seek(n, os.SEEK_CUR)
                     rest = buf.read()
                     buf = BytesIO()
                 buf.write(rest)

--- a/test/unit/transport/test_ssh.py
+++ b/test/unit/transport/test_ssh.py
@@ -24,6 +24,28 @@ rpc_reply = """<rpc-reply xmlns:junos="http://xml.juniper.net/junos/12.1X46/juno
 <rpc-reply/>"""
 
 
+rpc_reply_part_1 = """<rpc-reply xmlns:junos="http://xml.juniper.net/junos/12.1X46/junos" attrib1 = "test">
+    <software-information>
+        <host-name>R1</host-name>
+        <product-model>firefly-perimeter</product-model>
+        <product-name>firefly-perimeter</product-name>
+        <package-information>
+            <name>junos</name>
+            <comment>JUNOS Software Release [12.1X46-D10.2]</comment>
+        </package-information>
+    </software-information>
+    <cli>
+        <banner></banner>
+    </cli>
+</rpc-reply>
+]]>]]"""
+
+rpc_reply_part_2 = """>
+<rpc-reply>
+    <ok/>
+<rpc-reply/>"""
+
+
 class TestSSH(unittest.TestCase):
 
     @patch('ncclient.transport.ssh.Session._dispatch_message')
@@ -45,6 +67,27 @@ class TestSSH(unittest.TestCase):
             call = mock_dispatch.call_args_list[0][0][0]
             self.assertEqual(call, dispatched_str)
             self.assertEqual(obj._buffer.getvalue(), rpc_reply[515:])
+
+    @patch('ncclient.transport.ssh.Session._dispatch_message')
+    def test_parse_incomplete_delimiter(self, mock_dispatch):
+        device_handler = JunosDeviceHandler({'name': 'junos'})
+        obj = SSHSession(device_handler)
+        if sys.version >= "3.0":
+            b = bytes(rpc_reply_part_1, "utf-8")
+            obj._buffer.write(b)
+            obj._parse()
+            self.assertFalse(mock_dispatch.called)
+            b = bytes(rpc_reply_part_2, "utf-8")
+            obj._buffer.write(b)
+            obj._parse()
+            self.assertTrue(mock_dispatch.called)
+        else:
+            obj._buffer.write(rpc_reply_part_1)
+            obj._parse()
+            self.assertFalse(mock_dispatch.called)
+            obj._buffer.write(rpc_reply_part_2)
+            obj._parse()
+            self.assertTrue(mock_dispatch.called)
 
     @patch('paramiko.transport.Transport.auth_publickey')
     @patch('paramiko.agent.AgentSSH.get_keys')


### PR DESCRIPTION
When receiving a 4096 bytes message ending with ']]>]]', the remaining '>' is
prepend to the next message parsed.

This patch asserts that the delimiter ']]>]]>' is complete before parsing the
message, avoiding to prepend the next message with invalid characters.