### PR TITLE
support for datastores and configuration in validate

### DIFF
--- a/ncclient/operations/edit.py
+++ b/ncclient/operations/edit.py
@@ -104,22 +104,20 @@ class Validate(RPC):
 
     DEPENDS = [':validate']
 
-    def request(self, source="candidate"):
+    def request(self, source):
         """Validate the contents of the specified configuration.
 
         *source* is the name of the configuration datastore being validated or `config` element containing the configuration subtree to be validated
 
-
-        ** modified to only accept valid string as source argument.  Elements no longer accepted - earies - 04/22/2013
-
         :seealso: :ref:`srctarget_params`"""
         node = new_ele("validate")
-        # rfc6241 sec 8.6.4 states valid source can be <candidate> or <config> elements
-        tags = ("config", "candidate")
-        if source not in tags:
-            raise XMLError("Invalid source type: [%s], must be one of %s" % (source, tags))
-        src_ele = sub_ele(node, "source")
-        sub_ele(src_ele, source)
+        if type(source) is str:
+            src = util.datastore_or_url("source", source, self._assert)
+        else:
+            validated_element(source, ("config", qualify("config")))
+            src = new_ele("source")
+            src.append(source)
+        node.append(src)
         return self._request(node)
 
 

--- a/test/unit/operations/test_edit.py
+++ b/test/unit/operations/test_edit.py
@@ -102,22 +102,31 @@ class TestEdit(unittest.TestCase):
         session = ncclient.transport.SSHSession(self.device_handler)
         session._server_capabilities = [':validate']
         obj = Validate(session, self.device_handler, raise_mode=RaiseMode.ALL)
-        obj.request("config")
+        cfg_data = new_ele("config")
+        sub_ele(cfg_data, "data")
+        obj.request(cfg_data)
         node = new_ele("validate")
-        node = sub_ele(node, "source")
-        sub_ele(node, "config")
+        src = sub_ele(node, "source")
+        cfg = sub_ele(src, "config")
+        sub_ele(cfg, "data")
         xml = ElementTree.tostring(node, method='xml')
         call = mock_request.call_args_list[0][0][0]
         call = ElementTree.tostring(call, method='xml')
-        #self.assertEqual(call, xml)
+        self.assertEqual(call, xml)
 
     @patch('ncclient.operations.RPC._request')
     def test_validate_exception(self, mock_request):
         session = ncclient.transport.SSHSession(self.device_handler)
         session._server_capabilities = [':validate']
         obj = Validate(session, self.device_handler, raise_mode=RaiseMode.ALL)
-        with self.assertRaises(XMLError):
-            obj.request("running")
+        obj.request("candidate")
+        node = new_ele("validate")
+        src = sub_ele(node, "source")
+        sub_ele(src, "candidate")
+        xml = ElementTree.tostring(node, method='xml')
+        call = mock_request.call_args_list[0][0][0]
+        call = ElementTree.tostring(call, method='xml')
+        self.assertEqual(call, xml)
 
     @patch('ncclient.operations.RPC._request')
     def test_commit(self, mock_request):

--- a/test/unit/operations/test_edit.py
+++ b/test/unit/operations/test_edit.py
@@ -98,7 +98,7 @@ class TestEdit(unittest.TestCase):
         self.assertEqual(call, xml)
 
     @patch('ncclient.operations.RPC._request')
-    def test_validate(self, mock_request):
+    def test_validate_config(self, mock_request):
         session = ncclient.transport.SSHSession(self.device_handler)
         session._server_capabilities = [':validate']
         obj = Validate(session, self.device_handler, raise_mode=RaiseMode.ALL)
@@ -115,7 +115,7 @@ class TestEdit(unittest.TestCase):
         self.assertEqual(call, xml)
 
     @patch('ncclient.operations.RPC._request')
-    def test_validate_exception(self, mock_request):
+    def test_validate_datastore(self, mock_request):
         session = ncclient.transport.SSHSession(self.device_handler)
         session._server_capabilities = [':validate']
         obj = Validate(session, self.device_handler, raise_mode=RaiseMode.ALL)


### PR DESCRIPTION
The validate RPC is supposed to contain either a datastore name or a full configuration tree as the source (RFC 6241, 8.6.4.1). This change reflects that.
