### PR TITLE
Augmenting IOS-XR support

### DIFF
--- a/ncclient/devices/iosxr.py
+++ b/ncclient/devices/iosxr.py
@@ -12,7 +12,6 @@ generic information needed for interaction with a Netconf server.
 
 """
 
-from ncclient.xml_ import BASE_NS_1_0
 from ncclient.devices.default import DefaultDeviceHandler
 from ncclient.operations.third_party.iosxr.rpc import ExecuteRpc, Get, GetConfiguration
 
@@ -27,13 +26,6 @@ class IosxrDeviceHandler(DefaultDeviceHandler):
     """
     Cisco IOS-XR handler for device specific information.
     """
-
-    _EXEMPT_ERRORS = [
-        '*There is no message to reply.*'  # becasue the device replies with the following error
-        # when sending hello message:
-        # ERROR: 0xa367aa00 'XML Service Library' detected the 'fatal' condition 'There is no message to reply.'
-        # simply clever.
-    ]
 
     def __init__(self, device_params):
         super(IosxrDeviceHandler, self).__init__(device_params)
@@ -60,19 +52,6 @@ class IosxrDeviceHandler(DefaultDeviceHandler):
 
     def perform_qualify_check(self):
         return False
-
-    def get_xml_base_namespace_dict(self):
-
-        # default namespace
-        return {None: BASE_NS_1_0}
-
-    def get_xml_extra_prefix_kwargs(self):
-
-        return {
-            "nsmap": {
-                None: BASE_NS_1_0
-            }
-        }
 
     def transform_reply(self):
 

--- a/ncclient/devices/iosxr.py
+++ b/ncclient/devices/iosxr.py
@@ -12,26 +12,93 @@ generic information needed for interaction with a Netconf server.
 
 """
 
+from ncclient.xml_ import BASE_NS_1_0
+from ncclient.devices.default import DefaultDeviceHandler
+from ncclient.operations.third_party.iosxr.rpc import ExecuteRpc, Get, GetConfiguration
 
-from .default import DefaultDeviceHandler
 
 def iosxr_unknown_host_cb(host, fingerprint):
-        #This will ignore the unknown host check when connecting to IOS-XR devices
-        return True
+    # This will ignore the unknown host check when connecting to IOS-XR devices
+    return True
+
 
 class IosxrDeviceHandler(DefaultDeviceHandler):
-    """
-    Cisco IOS-XR handler for device specific information.
 
     """
+    Cisco IOS-XR handler for device specific information.
+    """
+
+    _EXEMPT_ERRORS = [
+        '*There is no message to reply.*'  # becasue the device replies with the following error
+        # when sending hello message:
+        # ERROR: 0xa367aa00 'XML Service Library' detected the 'fatal' condition 'There is no message to reply.'
+        # simply clever.
+    ]
+
     def __init__(self, device_params):
         super(IosxrDeviceHandler, self).__init__(device_params)
 
+    def add_additional_operations(self):
+
+        ops = {}
+
+        ops['rpc'] = ExecuteRpc  # for arbitrary XML RPC reqs
+        # get-config type RPC requsts might or might not have the <filter> tag
+        ops['get'] = Get
+        ops['get_config'] = GetConfiguration
+
+        # others seem to respect the standard
+
+        return ops
+
     def add_additional_ssh_connect_params(self, kwargs):
-        kwargs['allow_agent']   = False
+
+        kwargs['allow_agent'] = False
         kwargs['look_for_keys'] = False
         kwargs['hostkey_verify'] = False
         kwargs['unknown_host_cb'] = iosxr_unknown_host_cb
 
     def perform_qualify_check(self):
         return False
+
+    def get_xml_base_namespace_dict(self):
+
+        # default namespace
+        return {None: BASE_NS_1_0}
+
+    def get_xml_extra_prefix_kwargs(self):
+
+        return {
+            "nsmap": {
+                None: BASE_NS_1_0
+            }
+        }
+
+    def transform_reply(self):
+
+        # filter rpc-reply, strip namespaces
+        reply = '''<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+        <xsl:output method="xml" indent="no"/>
+        <xsl:template match="/|comment()|processing-instruction()">
+            <xsl:copy>
+                <xsl:apply-templates/>
+            </xsl:copy>
+        </xsl:template>
+        <xsl:template match="*">
+            <xsl:element name="{local-name()}">
+                <xsl:apply-templates select="@*|node()"/>
+            </xsl:element>
+        </xsl:template>
+        <xsl:template match="@*">
+            <xsl:attribute name="{local-name()}">
+                <xsl:value-of select="."/>
+            </xsl:attribute>
+        </xsl:template>
+        </xsl:stylesheet>
+        '''
+
+        import sys
+        if sys.version < '3':
+            return reply
+        else:
+            return reply.encode('UTF-8')

--- a/ncclient/operations/third_party/iosxr/rpc.py
+++ b/ncclient/operations/third_party/iosxr/rpc.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+"""
+IOS-XR custom RPC classes
+=========================
+
+Defines IOS-XR RPC specific classes.
+
+"""
+
+# import third party
+from lxml import etree
+
+# import ncclient
+from ncclient.xml_ import *
+from ncclient.operations import util
+from ncclient.operations.rpc import RPC
+
+
+class ExecuteRpc(RPC):
+
+    """
+    Executes arbitrary RPC requests.
+    """
+
+    def request(self, rpc_command):
+
+        """
+        Sends the RPC request as-is to the device.
+
+        :param rpc_command: The XML RPC request either as string/text either as XML object.
+        """
+        if etree.iselement(rpc_command):
+            node = rpc_command
+        else:
+            node = etree.fromstring(rpc_command)
+        return self._request(node)
+
+
+class GetConfiguration(RPC):
+
+    """
+    Retrieves config of specific configuration source.
+    """
+
+    def request(self, source=None, filter=None):
+
+        """
+        Builds the NETCONF <get-config> Request using the specified options.
+
+        :param source: Use specifiec configuration source: running/startup/candidate. Default: running.
+        :param filter: Filters the XML reply tree.
+        """
+        if source is None:
+            source = 'running'
+        get_config = new_ele('get-config')
+        if filter is not None:
+            filter_tree = sub_ele(get_config, 'filter')
+            if etree.iselement(filter):
+                filter_elem = filter
+            else:
+                filter_elem = etree.fromstring(filter)
+            filter_tree.append(filter_elem)
+        get_config.append(util.datastore_or_url('source', source, self._assert))
+        return self._request(get_config)
+
+
+class Get(RPC):
+
+    """
+    Retrieves running config.
+    """
+
+    def request(self, filter=None):
+
+        """
+        Builds the NETCONF <get-config> Request for the running config, using the specified filter.
+
+        :param filter: Filters the XML reply tree.
+        """
+
+        get_config = new_ele('get-config')
+        if filter is not None:
+            filter_tree = sub_ele(get_config, 'filter')
+            if etree.iselement(filter):
+                filter_elem = filter
+            else:
+                filter_elem = etree.fromstring(filter)
+            filter_tree.append(filter_elem)
+        get_config.append(util.datastore_or_url('source', 'running', self._assert))
+        return self._request(get_config)

--- a/ncclient/transport/ssh.py
+++ b/ncclient/transport/ssh.py
@@ -270,6 +270,7 @@ class SSHSession(Session):
         self._parsing_pos11 = self._buffer.tell()
         logger.debug('parse11 ending ...')
 
+
     def load_known_hosts(self, filename=None):
 
         """Load host keys from an openssh :file:`known_hosts`-style file. Can

--- a/ncclient/transport/ssh.py
+++ b/ncclient/transport/ssh.py
@@ -270,7 +270,6 @@ class SSHSession(Session):
         self._parsing_pos11 = self._buffer.tell()
         logger.debug('parse11 ending ...')
 
-
     def load_known_hosts(self, filename=None):
 
         """Load host keys from an openssh :file:`known_hosts`-style file. Can

--- a/ncclient/transport/third_party/iosxr/ioproc.py
+++ b/ncclient/transport/third_party/iosxr/ioproc.py
@@ -1,0 +1,85 @@
+import os
+import sys
+import re
+
+if sys.version < '3':
+    from cStringIO import StringIO
+else:
+    from io import StringIO
+from select import select
+if sys.version>='2.7':
+    from subprocess import Popen, check_output, PIPE, STDOUT
+else:
+    from subprocess import Popen, PIPE, STDOUT
+
+from ncclient.transport.errors import SessionCloseError, TransportError, PermissionError
+from ncclient.transport.ssh import SSHSession
+
+MSG_DELIM = "]]>]]>"
+NETCONF_SHELL = 'netconf'
+
+
+class IOProc(SSHSession):
+
+    def __init__(self, device_handler):
+        SSHSession.__init__(self, device_handler)
+        self._host_keys = None
+        self._transport = None
+        self._connected = False
+        self._channel = None
+        self._channel_id = None
+        self._channel_name = None
+        self._buffer = StringIO()  # for incoming data
+        # parsing-related, see _parse()
+        self._parsing_state = 0
+        self._parsing_pos = 0
+        self._device_handler = device_handler
+
+    def close(self):
+        self._channel.wait()
+        self._channel = None
+        self._connected = False
+
+    def connect(self):
+        stdoutdata = check_output(NETCONF_SHELL, shell=True, stdin=PIPE,
+                                  stderr=STDOUT)
+        if 'ERROR: 0x2431ae00' in stdoutdata:
+            raise PermissionError(stdoutdata)
+            # the message is pretty obvious
+        # ERROR: 0x2431ae00 'XML-TTY' detected the 'informational'
+        # condition 'The NETCONF Agent has not yet been started.
+        # Check that the configuration 'netconf agent tty' has been committed.'
+        self._channel = Popen(NETCONF_SHELL, shell=True,
+                              stdin=PIPE, stdout=PIPE, stderr=STDOUT)
+        self._connected = True
+        self._channel_id = self._channel.pid
+        self._channel_name = "netconf-shell"
+        self._post_connect()
+        return
+
+    def run(self):
+        chan = self._channel
+        q = self._q
+        try:
+            while True:
+                # write
+                data = q.get() + MSG_DELIM
+                chan.stdin.write(data)
+                chan.stdin.flush()
+                # read
+                data = []
+                while True:
+                    line = chan.stdout.readline()
+                    data.append(line)
+                    if MSG_DELIM in line:
+                        break
+                self._buffer.write(b''.join(data))
+                self._parse()
+        except Exception as e:
+            self._dispatch_error(e)
+            self.close()
+
+    @property
+    def transport(self):
+        "Underlying `paramiko.Transport <http://www.lag.net/paramiko/docs/paramiko.Transport-class.html>`_ object. This makes it possible to call methods like :meth:`~paramiko.Transport.set_keepalive` on it."
+        return self._transport

--- a/ncclient/xml_.py
+++ b/ncclient/xml_.py
@@ -36,8 +36,10 @@ class XMLError(NCClientError):
 
 ### Namespace-related
 
-#: Base NETCONF namespace
+#: Base NETCONF 1.0 namespace
 BASE_NS_1_0 = "urn:ietf:params:xml:ns:netconf:base:1.0"
+# Base NETCONF 1.1 namespace
+BASE_NS_1_1 = "urn:ietf:params:xml:ns:netconf:base:1.1"
 # NXOS_1_0
 NXOS_1_0 = "http://www.cisco.com/nxos:1.0"
 # NXOS_IF
@@ -64,7 +66,9 @@ H3C_CONFIG_1_0 = "http://www.h3c.com/netconf/config:1.0"
 H3C_ACTION_1_0 = "http://www.h3c.com/netconf/action:1.0"
 #: Namespace for netconf monitoring
 NETCONF_MONITORING_NS = "urn:ietf:params:xml:ns:yang:ietf-netconf-monitoring"
-#
+# IOSXR netconf 1.1
+IOSXR_1_1 = "urn:ietf:params:xml:ns:netconf:base:1.1"  # the base ns BASE_NS_1_1
+
 try:
     register_namespace = etree.register_namespace
 except AttributeError:


### PR DESCRIPTION
Currently the support for Cisco IOS-XR devices is not very well covered. However, they seem to have implemented properly most of the standard format requests.

The namespace changes in ```get_xml_extra_prefix_kwargs``` and ```get_xml_base_namespace_dict``` are important - the device does not seem to like qualified tags and even a hello message will fail if the RPC tag is formatted as ```<nc:hello>```, or ```<nc:rpc>```.

Basic functions such as ```lock```, ```unlock```, ```discard_changes``` etc can be issued using the default requests. I've added also support for executing arbitrary RPC requests and ```get``` or ```get_config``` with or without filter for ease of use (e.g.: ```conn.get()``` or ```conn.get(filter='<interface-configurations xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-ifmgr-cfg"/>')``` which provides only interfaces config etc.).