### PR TITLE
Use the _root obj already built

### DIFF
--- a/ncclient/xml_.py
+++ b/ncclient/xml_.py
@@ -196,7 +196,7 @@ class NCElement(object):
         self.__parser = etree.XMLParser(remove_blank_text=True)
         self.__xslt_doc = etree.parse(io.BytesIO(self.__xslt), self.__parser)
         self.__transform = etree.XSLT(self.__xslt_doc)
-        self.__root = etree.fromstring(str(self.__transform(etree.parse(StringIO(str(rpc_reply))))))
+        self.__root = etree.fromstring(str(self.__transform(rpc_reply._root)))
         return self.__root
 
 


### PR DESCRIPTION
Potentially fixes https://github.com/ncclient/ncclient/issues/151 as there's no obvious need to build yet another XML object when it is already parsed in https://github.com/ncclient/ncclient/blob/master/ncclient/operations/rpc.py#L139
Also I recall that StringIO in the past had some issues dealing with newline.

So far so good, however I will keep it a while in the production to see if behaves as expected:

```
2016-08-23 11:43:32,460 [ncclient.operations.rpc][DEBUG   ][31698] RPCReply.parse: raw parsed to:
2016-08-23 11:43:32,460 [ncclient.operations.rpc][DEBUG   ][31698] <Element {urn:ietf:params:xml:ns:netconf:base:1.0}rpc-reply at 0x7fc989da3170>
2016-08-23 11:43:32,460 [ncclient.operations.rpc][DEBUG   ][31698] <rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" xmlns:junos="http://xml.juniper.net/junos/14.2R6/junos" xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="urn:uuid:3e070d62-917f-429d-8fc4-578984378f76">
<output>
Current time: 2016-08-23 11:43:31 UTC
System booted: 2016-07-15 00:17:35 UTC (5w4d 11:25 ago)
Protocols started: 2016-07-15 00:20:32 UTC (5w4d 11:22 ago)
Last configured: 2016-08-22 10:02:38 UTC (1d 01:40 ago) by netconf
11:43AM  up 39 days, 11:26, 3 users, load averages: 0.21, 0.27, 0.29
</output>
</rpc-reply>
2016-08-23 11:43:32,460 [ncclient.operations.rpc][DEBUG   ][31698] RPC._request: will transform reply
2016-08-23 11:43:32,460 [ncclient.xml_    ][DEBUG   ][31698] removing namespaces
2016-08-23 11:43:32,461 [ncclient.xml_    ][DEBUG   ][31698] string io
2016-08-23 11:43:32,461 [ncclient.xml_    ][DEBUG   ][31698] <StringIO.StringIO instance at 0x7fc989da35f0>
2016-08-23 11:43:32,461 [ncclient.xml_    ][DEBUG   ][31698] after removing namespaces
2016-08-23 11:43:32,461 [ncclient.xml_    ][DEBUG   ][31698] <rpc-reply message-id="urn:uuid:3e070d62-917f-429d-8fc4-578984378f76">
<output>
Current time: 2016-08-23 11:43:31 UTC
System booted: 2016-07-15 00:17:35 UTC (5w4d 11:25 ago)
Protocols started: 2016-07-15 00:20:32 UTC (5w4d 11:22 ago)
Last configured: 2016-08-22 10:02:38 UTC (1d 01:40 ago) by netconf
11:43AM  up 39 days, 11:26, 3 users, load averages: 0.21, 0.27, 0.29
</output>
</rpc-reply>
2016-08-23 11:43:32,461 [ncclient.operations.rpc][DEBUG   ][31698] RPC._request: reply transformed
2016-08-23 11:43:32,462 [ncclient.operations.rpc][DEBUG   ][31698] Print _NCElement__doc
2016-08-23 11:43:32,462 [ncclient.operations.rpc][DEBUG   ][31698] <rpc-reply message-id="urn:uuid:3e070d62-917f-429d-8fc4-578984378f76">
<output>
Current time: 2016-08-23 11:43:31 UTC
System booted: 2016-07-15 00:17:35 UTC (5w4d 11:25 ago)
Protocols started: 2016-07-15 00:20:32 UTC (5w4d 11:22 ago)
Last configured: 2016-08-22 10:02:38 UTC (1d 01:40 ago) by netconf
11:43AM  up 39 days, 11:26, 3 users, load averages: 0.21, 0.27, 0.29
</output>
</rpc-reply>
2016-08-23 11:43:32,462 [ncclient.operations.rpc][DEBUG   ][31698] print data_xml
2016-08-23 11:43:32,462 [ncclient.operations.rpc][DEBUG   ][31698] <?xml version="1.0" encoding="UTF-8"?><rpc-reply message-id="urn:uuid:3e070d62-917f-429d-8fc4-578984378f76">
<output>
Current time: 2016-08-23 11:43:31 UTC
System booted: 2016-07-15 00:17:35 UTC (5w4d 11:25 ago)
Protocols started: 2016-07-15 00:20:32 UTC (5w4d 11:22 ago)
Last configured: 2016-08-22 10:02:38 UTC (1d 01:40 ago) by netconf
11:43AM  up 39 days, 11:26, 3 users, load averages: 0.21, 0.27, 0.29
</output>
</rpc-reply>
```