### PR TITLE
Updated setup.py enforcing utf-8 read

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ if sys.version_info[0] == 2 and sys.version_info[1] < 6:
 req_lines = [line.strip() for line in open("requirements.txt").readlines()]
 install_reqs = list(filter(None, req_lines))
 
-with open('README.rst') as file:
+with open('README.rst', encoding='utf-8') as file:
     long_description = file.read()
 
 


### PR DESCRIPTION
I have found that python3.x installation via pip is failing due to python3 "UnicodeDecodeError" (see below).

UnicodeDecodeError: 'ascii' codec can't decode byte 0xd0 in position 4335: ordinal not in range(128)

This change simply enforces utf-8 read in of the readme.rst file and allows for the package to install correctly.