### PR TITLE
Remove dangerous 'recover=True' option from XMLParser

### DIFF
--- a/ncclient/xml_.py
+++ b/ncclient/xml_.py
@@ -29,7 +29,7 @@ from lxml import etree
 
 from ncclient import NCClientError
 
-parser = etree.XMLParser(recover=True)
+parser = etree.XMLParser(recover=False)
 
 class XMLError(NCClientError):
     pass

--- a/test/unit/operations/test_utils.py
+++ b/test/unit/operations/test_utils.py
@@ -7,7 +7,7 @@ xml = """<filter type="xpath">
         <configuration>
             <system>
                 <services/>
-            <system>
+            </system>
         </configuration>
     </filter>"""
 
@@ -70,7 +70,7 @@ class TestUtils(unittest.TestCase):
         criteria =  """<configuration>
             <system>
                 <services/>
-            <system>
+            </system>
         </configuration>"""
         filter = ("subtree", criteria)
         reply = build_filter(filter, capcheck="cap")
@@ -83,7 +83,7 @@ class TestUtils(unittest.TestCase):
         criteria =  """<configuration>
             <system>
                 <services/>
-            <system>
+            </system>
         </configuration>"""
         filter = ("text", criteria)
         self.assertRaises(OperationError,

--- a/test/unit/operations/third_party/juniper/test_rpc.py
+++ b/test/unit/operations/third_party/juniper/test_rpc.py
@@ -168,7 +168,7 @@ class TestRPC(unittest.TestCase):
         device_handler = manager.make_device_handler({'name': 'junos'})
         session = ncclient.transport.SSHSession(device_handler)
         obj = ExecuteRpc(session, device_handler, raise_mode=RaiseMode.ALL)
-        rpc = 'get-software-information'
+        rpc = '<get-software-information/>'
         obj.request(rpc)
         self.assertEqual(True, isinstance(rpc, str))
 

--- a/test/unit/transport/test_session.py
+++ b/test/unit/transport/test_session.py
@@ -35,47 +35,6 @@ hello_rpc_reply = """<hello>
 </hello>
 """
 
-cap_excahnge_err_reply="""warning: user "pyez-ua" does not have access privileges.
-
-error: Restricted user session.
-<!-- No zombies were killed during the creation of this user interface -->
-<rpc-reply>
-<rpc-error>
-<error-severity>warning</error-severity>
-<error-message>
-user "pyez-ua" does not have access privileges.
-</error-message>
-</rpc-error>
-</rpc-reply>
-<rpc-reply>
-<rpc-error>
-<error-type>protocol</error-type>
-<error-tag>operation-failed</error-tag>
-<error-severity>error</error-severity>
-<error-message>
-Restricted user session.
-</error-message>
-</rpc-error>
-</rpc-reply>
-<!-- user nobody, class (unknown) -->
-<hello xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
-  <capabilities>
-    <capability>urn:ietf:params:netconf:base:1.0</capability>
-    <capability>urn:ietf:params:netconf:capability:candidate:1.0</capability>
-    <capability>urn:ietf:params:netconf:capability:confirmed-commit:1.0</capability>
-    <capability>urn:ietf:params:netconf:capability:validate:1.0</capability>
-    <capability>urn:ietf:params:netconf:capability:url:1.0?scheme=http,ftp,file</capability>
-    <capability>urn:ietf:params:xml:ns:netconf:base:1.0</capability>
-    <capability>urn:ietf:params:xml:ns:netconf:capability:candidate:1.0</capability>
-    <capability>urn:ietf:params:xml:ns:netconf:capability:confirmed-commit:1.0</capability>
-    <capability>urn:ietf:params:xml:ns:netconf:capability:validate:1.0</capability>
-    <capability>urn:ietf:params:xml:ns:netconf:capability:url:1.0?protocol=http,ftp,file</capability>
-    <capability>http://xml.juniper.net/netconf/junos/1.0</capability>
-    <capability>http://xml.juniper.net/dmi/system/1.0</capability>
-  </capabilities>
-  <session-id>59894</session-id>
-</hello>"""
-
 notification="""
    <notification
       xmlns="urn:ietf:params:xml:ns:netconf:notification:1.0">
@@ -116,22 +75,6 @@ class TestSession(unittest.TestCase):
         obj._dispatch_message(rpc_reply)
         self.assertNotEqual(
             mock_log.call_args_list[0][0][0].find("error parsing dispatch message"), -1)
-
-    @patch('ncclient.transport.session.parse_root')
-    @patch('logging.Logger.debug')
-    def test_dispatch_msg_err_during_cap_exchange(self, mock_log, mock_parse_root):
-        mock_parse_root.side_effect = Exception
-        logging.basicConfig(level=logging.CRITICAL)
-        cap = [':candidate']
-        obj = Session(cap)
-        device_handler = JunosDeviceHandler({'name': 'junos'})
-        obj._device_handler = device_handler
-        listener = HelloHandler(None, None)
-        obj._listeners.add(listener)
-        obj._dispatch_message(cap_excahnge_err_reply)
-        self.assertNotEqual(
-            mock_log.call_args_list[1][0][0].find("dispatching error to"), -1)
-
 
     @patch('ncclient.transport.session.HelloHandler.errback')
     def test_dispatch_error(self, mock_handler):


### PR DESCRIPTION
This option was added via commit 858a13acd16043d1682f469a6274befe618a1d2b back in 2014.  This means that clients must do full validation of content prior to calling ncclient.

This option is dangerous and can result in broken XML being silently discarded with unintended consequences (consider options to an RPC call that were meant to be specific that may have been invalid).  The end result is some XML could still pass and be constructed.

If this was necessary to deal with broken XML then it should be fixed at the endpoint and not reside in core infra.