### PR TITLE
try authorizing by password prior to trying with keys

### DIFF
--- a/ncclient/transport/ssh.py
+++ b/ncclient/transport/ssh.py
@@ -439,6 +439,14 @@ class SSHSession(Session):
               look_for_keys):
         saved_exception = None
 
+        if password is not None:
+            try:
+                self._transport.auth_password(username, password)
+                return
+            except Exception as e:
+                saved_exception = e 
+                logger.debug(e)
+
         for key_filename in key_filenames:
             for cls in (paramiko.RSAKey, paramiko.DSSKey, paramiko.ECDSAKey):
                 try:
@@ -490,14 +498,6 @@ class SSHSession(Session):
                 logger.debug("Trying discovered key %s in %s" %
                           (hexlify(key.get_fingerprint()), filename))
                 self._transport.auth_publickey(username, key)
-                return
-            except Exception as e:
-                saved_exception = e
-                logger.debug(e)
-
-        if password is not None:
-            try:
-                self._transport.auth_password(username, password)
                 return
             except Exception as e:
                 saved_exception = e


### PR DESCRIPTION
Hello,

I am having some issues when establishing a NETCONF connection. 
This is due to the fact that although under /root/.ssh there are keys (on the client side), however i want to authenticate to this server via password. These keys are there for other applications. 

So i moved the password authentication prior to the keys.

Regards
Nikos