### PR TITLE
async rpc request example 

### DIFF
--- a/examples/juniper/execute-async-rpc.py
+++ b/examples/juniper/execute-async-rpc.py
@@ -1,0 +1,38 @@
+from ncclient import manager
+from ncclient.xml_ import *
+import time
+from ncclient.devices.junos import JunosDeviceHandler
+
+
+def connect(host, port, user, password):
+    conn = manager.connect(host=host,
+                           port=port,
+                           username=user,
+                           password=password,
+                           timeout=10,
+                           device_params={'name': 'junos'},
+                           hostkey_verify=False)
+
+    junos_dev_handler = JunosDeviceHandler(
+        device_params={'name': 'junos',
+                       'local': False})
+
+    conn.async_mode = True
+
+    rpc = new_ele('get-software-information')
+    obj = conn.rpc(rpc)
+
+    # for demo purposes, we just wait for the result 
+    while not obj.event.is_set():
+        print('waiting for answer ...')
+        time.sleep(.3)
+
+    result = NCElement(obj.reply,
+                       junos_dev_handler.transform_reply()
+                       ).remove_namespaces(obj.reply.xml)
+
+    print 'Hostname: ', result.findtext('.//host-name')
+
+
+if __name__ == '__main__':
+    connect('router', 830, 'netconf', 'juniper!')

--- a/examples/juniper/outbound-ssh-ncclient.py
+++ b/examples/juniper/outbound-ssh-ncclient.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+
+"""
+ Listen on TCP port 2200 for incoming SSH session from Junos devices with
+ the following ssh outbound configuration and collect host-name and junos-version
+ upon connect, then terminate
+
+ lab@router> show configuration system services outbound-ssh
+ client outbound-ssh-ncclient {
+     device-id vRR;
+     services netconf;
+     10.0.2.2 port 2200;
+  }
+
+ Example:
+
+ $ ./outbound-ssh-ncclient.py
+ Listening on port 2200 for incoming sessions ...
+ Got a connection from 172.17.0.1:48038!
+ MSG DEVICE-CONN-INFO V1 vRR
+ Logging in ...
+ requesting info...
+   Hostname: vRR
+    Version: 16.1R3.10
+ $
+"""
+
+
+import sys
+import socket
+import time
+
+from ncclient import manager
+from ncclient.xml_ import *
+
+
+def listener(port, user, password):
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    s.bind(('', port))
+    s.listen(5)
+    print('Listening on port %d for incoming sessions ...' % (port))
+    while True:
+        client, addr = s.accept()
+        print('Got a connection from %s:%d!' % (addr[0], addr[1]))
+        launch_junos_proxy(client, addr, user, password)
+
+
+def launch_junos_proxy(client, addr, user, password):
+    val = {
+        'MSG-ID': None,
+        'MSG-VER': None,
+        'DEVICE-ID': None
+    }
+    msg = ''
+    count = 3
+    while len(msg) < 100 and count > 0:
+        c = client.recv(1)
+        if c == '\r':
+            continue
+
+        if c == '\n':
+            count -= 1
+            if msg.find(':'):
+                (key, value) = msg.split(': ')
+                val[key] = value
+                msg = ''
+        else:
+            msg += c
+
+    print('MSG %s %s %s' % (val['MSG-ID'], val['MSG-VER'], val['DEVICE-ID']))
+    print('Logging in ...')
+
+    sock_fd = client.fileno()
+    conn = manager.connect(host=None,
+                           sock_fd=sock_fd,
+                           username=user,
+                           password=password,
+                           timeout=10,
+                           device_params={'name': 'junos'},
+                           hostkey_verify=False)
+
+    rpc = new_ele('get-software-information')
+
+    print('requesting info...')
+    result = conn.rpc(rpc)
+    print '   Hostname:', result.xpath('//software-information/host-name')[0].text
+    print '    Version:', result.xpath('//software-information/junos-version')[0].text
+    sys.exit(0)
+
+
+if __name__ == '__main__':
+    listener(2200, 'netconf', 'juniper!')

--- a/ncclient/transport/ssh.py
+++ b/ncclient/transport/ssh.py
@@ -317,7 +317,7 @@ class SSHSession(Session):
     # REMEMBER to update transport.rst if sig. changes, since it is hardcoded there
     def connect(self, host, port=830, timeout=None, unknown_host_cb=default_unknown_host_cb,
                 username=None, password=None, key_filename=None, allow_agent=True,
-                hostkey_verify=True, look_for_keys=True, ssh_config=None):
+                hostkey_verify=True, look_for_keys=True, ssh_config=None, sock=None):
 
         """Connect via SSH and initialize the NETCONF session. First attempts the publickey authentication method and then password authentication.
 
@@ -344,7 +344,12 @@ class SSHSession(Session):
         *look_for_keys* enables looking in the usual locations for ssh keys (e.g. :file:`~/.ssh/id_*`)
 
         *ssh_config* enables parsing of an OpenSSH configuration file, if set to its path, e.g. :file:`~/.ssh/config` or to True (in this case, use :file:`~/.ssh/config`).
+
+        *sock* is an already open socket which shall be used for this connection. Useful for NETCONF Call Home.
         """
+        if not (host or socket):
+            raise SSHError("Missing host or socket")
+
         # Optionaly, parse .ssh/config
         config = {}
         if ssh_config is True:
@@ -362,25 +367,27 @@ class SSHSession(Session):
         if username is None:
             username = getpass.getuser()
 
-        sock = None
-        if config.get("proxycommand"):
-            sock = paramiko.proxy.ProxyCommand(config.get("proxycommand"))
-        else:
-            for res in socket.getaddrinfo(host, port, socket.AF_UNSPEC, socket.SOCK_STREAM):
-                af, socktype, proto, canonname, sa = res
-                try:
-                    sock = socket.socket(af, socktype, proto)
-                    sock.settimeout(timeout)
-                except socket.error:
-                    continue
-                try:
-                    sock.connect(sa)
-                except socket.error:
-                    sock.close()
-                    continue
-                break
+        if sock is None:
+            if config.get("proxycommand"):
+                sock = paramiko.proxy.ProxyCommand(config.get("proxycommand"))
             else:
-                raise SSHError("Could not open socket to %s:%s" % (host, port))
+                for res in socket.getaddrinfo(host, port, socket.AF_UNSPEC, socket.SOCK_STREAM):
+                    af, socktype, proto, canonname, sa = res
+                    try:
+                        sock = socket.socket(af, socktype, proto)
+                        sock.settimeout(timeout)
+                    except socket.error:
+                        continue
+                    try:
+                        sock.connect(sa)
+                    except socket.error:
+                        sock.close()
+                        continue
+                    break
+                else:
+                    raise SSHError("Could not open socket to %s:%s" % (host, port))
+        else:
+            sock.settimeout(timeout)
 
         t = self._transport = paramiko.Transport(sock)
         t.set_log_channel(logger.name)

--- a/ncclient/transport/ssh.py
+++ b/ncclient/transport/ssh.py
@@ -345,7 +345,7 @@ class SSHSession(Session):
 
         *ssh_config* enables parsing of an OpenSSH configuration file, if set to its path, e.g. :file:`~/.ssh/config` or to True (in this case, use :file:`~/.ssh/config`).
 
-        *sock_fd* is an already open socket which shall be used for this connection. Useful for NETCONF Call Home.
+        *sock_fd* is an already open socket which shall be used for this connection. Useful for NETCONF outbound ssh. Use host=None together with a valid sock_fd number
         """
         if not (host or sock_fd):
             raise SSHError("Missing host or socket fd")


### PR DESCRIPTION
This script connects to a Juniper device and issues an asynchronous rpc request for get-software-information, then waits for the action to complete and prints out the hostname. 

Contrary to a synchronous rpc call [execute-rpc.py](https://github.com/ncclient/ncclient/blob/master/examples/juniper/execute-rpc.py), more work is required to parse the reply.