### PR TITLE
juniper async rpc example

### DIFF
--- a/examples/juniper/execute-async-rpc.py
+++ b/examples/juniper/execute-async-rpc.py
@@ -1,0 +1,38 @@
+from ncclient import manager
+from ncclient.xml_ import *
+import time
+from ncclient.devices.junos import JunosDeviceHandler
+
+
+def connect(host, port, user, password):
+    conn = manager.connect(host=host,
+                           port=port,
+                           username=user,
+                           password=password,
+                           timeout=10,
+                           device_params={'name': 'junos'},
+                           hostkey_verify=False)
+
+    junos_dev_handler = JunosDeviceHandler(
+        device_params={'name': 'junos',
+                       'local': False})
+
+    conn.async_mode = True
+
+    rpc = new_ele('get-software-information')
+    obj = conn.rpc(rpc)
+
+    # for demo purposes, we just wait for the result 
+    while not obj.event.is_set():
+        print('waiting for answer ...')
+        time.sleep(.3)
+
+    result = NCElement(obj.reply,
+                       junos_dev_handler.transform_reply()
+                       ).remove_namespaces(obj.reply.xml)
+
+    print 'Hostname: ', result.findtext('.//host-name')
+
+
+if __name__ == '__main__':
+    connect('router', 830, 'netconf', 'juniper!')


### PR DESCRIPTION
This script connects to a Juniper device and issues an asynchronous rpc request for get-software-information, then waits for the action to complete and prints out the hostname. 

Contrary to a synchronous rpc call [execute-rpc.py](https://github.com/ncclient/ncclient/blob/master/examples/juniper/execute-rpc.py), more work is required to parse the reply.