### PR TITLE
Juniper outbound-ssh support

### DIFF
--- a/examples/juniper/outbound-ssh-ncclient.py
+++ b/examples/juniper/outbound-ssh-ncclient.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+
+"""
+ Listen on TCP port 2200 for incoming SSH session from Junos devices with
+ the following ssh outbound configuration and collect host-name and junos-version
+ upon connect, then terminate
+
+ lab@router> show configuration system services outbound-ssh
+ client outbound-ssh-ncclient {
+     device-id vRR;
+     services netconf;
+     10.0.2.2 port 2200;
+  }
+
+ Example:
+
+ $ ./outbound-ssh-ncclient.py
+ Listening on port 2200 for incoming sessions ...
+ Got a connection from 172.17.0.1:48038!
+ MSG DEVICE-CONN-INFO V1 vRR
+ Logging in ...
+ requesting info...
+   Hostname: vRR
+    Version: 16.1R3.10
+ $
+"""
+
+
+import sys
+import socket
+import time
+
+from ncclient import manager
+from ncclient.xml_ import *
+
+
+def listener(port, user, password):
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    s.bind(('', port))
+    s.listen(5)
+    print('Listening on port %d for incoming sessions ...' % (port))
+    while True:
+        client, addr = s.accept()
+        print('Got a connection from %s:%d!' % (addr[0], addr[1]))
+        launch_junos_proxy(client, addr, user, password)
+
+
+def launch_junos_proxy(client, addr, user, password):
+    val = {
+        'MSG-ID': None,
+        'MSG-VER': None,
+        'DEVICE-ID': None
+    }
+    msg = ''
+    count = 3
+    while len(msg) < 100 and count > 0:
+        c = client.recv(1)
+        if c == '\r':
+            continue
+
+        if c == '\n':
+            count -= 1
+            if msg.find(':'):
+                (key, value) = msg.split(': ')
+                val[key] = value
+                msg = ''
+        else:
+            msg += c
+
+    print('MSG %s %s %s' % (val['MSG-ID'], val['MSG-VER'], val['DEVICE-ID']))
+    print('Logging in ...')
+
+    sock_fd = client.fileno()
+    conn = manager.connect(host=None,
+                           sock_fd=sock_fd,
+                           username=user,
+                           password=password,
+                           timeout=10,
+                           device_params={'name': 'junos'},
+                           hostkey_verify=False)
+
+    rpc = new_ele('get-software-information')
+
+    print('requesting info...')
+    result = conn.rpc(rpc)
+    print '   Hostname:', result.xpath('//software-information/host-name')[0].text
+    print '    Version:', result.xpath('//software-information/junos-version')[0].text
+    sys.exit(0)
+
+
+if __name__ == '__main__':
+    listener(2200, 'netconf', 'juniper!')

--- a/examples/juniper/outbound-ssh-ncclient.py
+++ b/examples/juniper/outbound-ssh-ncclient.py
@@ -56,6 +56,7 @@ def launch_junos_proxy(client, addr, user, password):
     count = 3
     while len(msg) < 100 and count > 0:
         c = client.recv(1)
+        c = c.decode()
         if c == '\r':
             continue
 
@@ -84,8 +85,8 @@ def launch_junos_proxy(client, addr, user, password):
 
     print('requesting info...')
     result = conn.rpc(rpc)
-    print '   Hostname:', result.xpath('//software-information/host-name')[0].text
-    print '    Version:', result.xpath('//software-information/junos-version')[0].text
+    print('   Hostname: ' +  result.xpath('//software-information/host-name')[0].text)
+    print('    Version: ' + result.xpath('//software-information/junos-version')[0].text)
     sys.exit(0)
 
 

--- a/ncclient/transport/ssh.py
+++ b/ncclient/transport/ssh.py
@@ -387,8 +387,11 @@ class SSHSession(Session):
                 else:
                     raise SSHError("Could not open socket to %s:%s" % (host, port))
         else:
-            s = socket.fromfd(int(sock_fd), socket.AF_INET, socket.SOCK_STREAM)
-            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM, _sock=s)
+            if sys.version_info[0] < 3:
+                s = socket.fromfd(int(sock_fd), socket.AF_INET, socket.SOCK_STREAM)
+                sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM, _sock=s)
+            else:
+                sock = socket.fromfd(int(sock_fd), socket.AF_INET, socket.SOCK_STREAM)
             sock.settimeout(timeout)
 
         t = self._transport = paramiko.Transport(sock)

--- a/ncclient/transport/ssh.py
+++ b/ncclient/transport/ssh.py
@@ -317,7 +317,7 @@ class SSHSession(Session):
     # REMEMBER to update transport.rst if sig. changes, since it is hardcoded there
     def connect(self, host, port=830, timeout=None, unknown_host_cb=default_unknown_host_cb,
                 username=None, password=None, key_filename=None, allow_agent=True,
-                hostkey_verify=True, look_for_keys=True, ssh_config=None):
+                hostkey_verify=True, look_for_keys=True, ssh_config=None, sock=None):
 
         """Connect via SSH and initialize the NETCONF session. First attempts the publickey authentication method and then password authentication.
 
@@ -344,7 +344,12 @@ class SSHSession(Session):
         *look_for_keys* enables looking in the usual locations for ssh keys (e.g. :file:`~/.ssh/id_*`)
 
         *ssh_config* enables parsing of an OpenSSH configuration file, if set to its path, e.g. :file:`~/.ssh/config` or to True (in this case, use :file:`~/.ssh/config`).
+
+        *sock* is an already open socket which shall be used for this connection. Useful for NETCONF Call Home.
         """
+        if not (host or socket):
+            raise SSHError("Missing host or socket")
+
         # Optionaly, parse .ssh/config
         config = {}
         if ssh_config is True:
@@ -362,25 +367,27 @@ class SSHSession(Session):
         if username is None:
             username = getpass.getuser()
 
-        sock = None
-        if config.get("proxycommand"):
-            sock = paramiko.proxy.ProxyCommand(config.get("proxycommand"))
-        else:
-            for res in socket.getaddrinfo(host, port, socket.AF_UNSPEC, socket.SOCK_STREAM):
-                af, socktype, proto, canonname, sa = res
-                try:
-                    sock = socket.socket(af, socktype, proto)
-                    sock.settimeout(timeout)
-                except socket.error:
-                    continue
-                try:
-                    sock.connect(sa)
-                except socket.error:
-                    sock.close()
-                    continue
-                break
+        if sock is None:
+            if config.get("proxycommand"):
+                sock = paramiko.proxy.ProxyCommand(config.get("proxycommand"))
             else:
-                raise SSHError("Could not open socket to %s:%s" % (host, port))
+                for res in socket.getaddrinfo(host, port, socket.AF_UNSPEC, socket.SOCK_STREAM):
+                    af, socktype, proto, canonname, sa = res
+                    try:
+                        sock = socket.socket(af, socktype, proto)
+                        sock.settimeout(timeout)
+                    except socket.error:
+                        continue
+                    try:
+                        sock.connect(sa)
+                    except socket.error:
+                        sock.close()
+                        continue
+                    break
+                else:
+                    raise SSHError("Could not open socket to %s:%s" % (host, port))
+        else:
+            sock.settimeout(timeout)
 
         t = self._transport = paramiko.Transport(sock)
         t.set_log_channel(logger.name)

--- a/ncclient/transport/ssh.py
+++ b/ncclient/transport/ssh.py
@@ -345,7 +345,7 @@ class SSHSession(Session):
 
         *ssh_config* enables parsing of an OpenSSH configuration file, if set to its path, e.g. :file:`~/.ssh/config` or to True (in this case, use :file:`~/.ssh/config`).
 
-        *sock_fd* is an already open socket which shall be used for this connection. Useful for NETCONF Call Home.
+        *sock_fd* is an already open socket which shall be used for this connection. Useful for NETCONF outbound ssh. Use host=None together with a valid sock_fd number
         """
         if not (host or sock_fd):
             raise SSHError("Missing host or socket fd")

--- a/test/unit/test_manager.py
+++ b/test/unit/test_manager.py
@@ -18,6 +18,11 @@ class TestManager(unittest.TestCase):
         manager.connect(host='host')
         mock_ssh.assert_called_once_with(host='host')
 
+    @patch('ncclient.manager.connect_ssh')
+    def test_connect_outbound_ssh(self, mock_ssh):
+        manager.connect(host=None, sock_fd=6)
+        mock_ssh.assert_called_once_with(host=None, sock_fd=6)
+
     @patch('ncclient.manager.connect_ioproc')
     def test_connect_ioproc(self, mock_ssh):
         manager.connect(host='localhost', device_params={'name': 'junos', 
@@ -128,6 +133,25 @@ class TestManager(unittest.TestCase):
     def _mock_manager(self):
         conn = manager.connect(host='10.10.10.10',
                                     port=22,
+                                    username='user',
+                                    password='password',
+                                    timeout=10,
+                                    device_params={'name': 'junos'},
+                                    hostkey_verify=False, allow_agent=False)
+        return conn
+
+    @patch('socket.fromfd')
+    @patch('paramiko.Transport')
+    @patch('ncclient.transport.ssh.hexlify')
+    @patch('ncclient.transport.ssh.Session._post_connect')
+    def test_outbound_manager_connected(
+            self, mock_session, mock_hex, mock_trans, mock_fromfd):
+        conn = self._mock_outbound_manager()
+        self.assertEqual(conn.connected, True)
+
+    def _mock_outbound_manager(self):
+        conn = manager.connect(host=None,
+                                    sock_fd=6,
                                     username='user',
                                     password='password',
                                     timeout=10,


### PR DESCRIPTION
Cherry-pick open pull request #67, which allows the use of an already open socket for the ssh connection via ssh, but use a socket file descriptor instead of the socket object in order to pass it as number between processes. 

This change is required for PyEz and SaltStack Proxy to support Junos outbound ssh by running a salt-proxy daemon on a given TCP port and fork per incoming connection based on DEVICE-ID.

Example script with required Junos configuration can be found in [examples/juniper/outbound-ssh-ncclient.py](https://github.com/mwiget/ncclient/blob/outbound-ssh/examples/juniper/outbound-ssh-ncclient.py).

Related PyEz and SaltStack "work-in-progress" changes can be found in 
[https://github.com/mwiget/py-junos-eznc/tree/outbound-ssh](https://github.com/mwiget/py-junos-eznc/tree/outbound-ssh)
[https://github.com/mwiget/salt/tree/junos-outbound-ssh](https://github.com/mwiget/salt/tree/junos-outbound-ssh)

Feedback welcome.