### PR TITLE
Added "with-defaults" capability for "get" and "get-config" requests

### DIFF
--- a/ncclient/devices/default.py
+++ b/ncclient/devices/default.py
@@ -93,7 +93,8 @@ class DefaultDeviceHandler(object):
             "urn:ietf:params:netconf:capability:xpath:1.0",
             "urn:ietf:params:netconf:capability:notification:1.0",
             "urn:liberouter:params:netconf:capability:power-control:1.0",
-            "urn:ietf:params:netconf:capability:interleave:1.0"
+            "urn:ietf:params:netconf:capability:interleave:1.0",
+            "urn:ietf:params:netconf:capability:with-defaults:1.0"
         ]
 
     def get_xml_base_namespace_dict(self):
@@ -220,4 +221,3 @@ class DefaultDeviceHandler(object):
 
     def transform_reply(self):
         return False
-

--- a/ncclient/xml_.py
+++ b/ncclient/xml_.py
@@ -66,6 +66,8 @@ H3C_ACTION_1_0 = "http://www.h3c.com/netconf/action:1.0"
 NETCONF_MONITORING_NS = "urn:ietf:params:xml:ns:yang:ietf-netconf-monitoring"
 #: Namespace for netconf notifications
 NETCONF_NOTIFICATION_NS = "urn:ietf:params:xml:ns:netconf:notification:1.0"
+#: Namespace for netconf with-defaults (RFC 6243)
+NETCONF_WITH_DEFAULTS_NS = "urn:ietf:params:xml:ns:yang:ietf-netconf-with-defaults"
 #
 try:
     register_namespace = etree.register_namespace
@@ -207,3 +209,5 @@ new_ele = lambda tag, attrs={}, **extra: etree.Element(qualify(tag), attrs, **ex
 new_ele_ns = lambda tag, ns, attrs={}, **extra: etree.Element(qualify(tag,ns), attrs, **extra)
 
 sub_ele = lambda parent, tag, attrs={}, **extra: etree.SubElement(parent, qualify(tag), attrs, **extra)
+
+sub_ele_ns = lambda parent, tag, ns, attrs={}, **extra: etree.SubElement(parent, qualify(tag, ns), attrs, **extra)

--- a/test/unit/devices/test_default.py
+++ b/test/unit/devices/test_default.py
@@ -3,18 +3,19 @@ from ncclient.devices.default import DefaultDeviceHandler
 
 
 capabilities = ['urn:ietf:params:netconf:base:1.0',
-                 'urn:ietf:params:netconf:base:1.1', 
-                'urn:ietf:params:netconf:capability:writable-running:1.0', 
-                'urn:ietf:params:netconf:capability:candidate:1.0', 
-                'urn:ietf:params:netconf:capability:confirmed-commit:1.0', 
-                'urn:ietf:params:netconf:capability:rollback-on-error:1.0', 
-                'urn:ietf:params:netconf:capability:startup:1.0', 
-                'urn:ietf:params:netconf:capability:url:1.0?scheme=http,ftp,file,https,sftp', 
-                'urn:ietf:params:netconf:capability:validate:1.0', 
-                'urn:ietf:params:netconf:capability:xpath:1.0', 
-                'urn:ietf:params:netconf:capability:notification:1.0', 
-                'urn:liberouter:params:netconf:capability:power-control:1.0', 
-                'urn:ietf:params:netconf:capability:interleave:1.0']
+                'urn:ietf:params:netconf:base:1.1',
+                'urn:ietf:params:netconf:capability:writable-running:1.0',
+                'urn:ietf:params:netconf:capability:candidate:1.0',
+                'urn:ietf:params:netconf:capability:confirmed-commit:1.0',
+                'urn:ietf:params:netconf:capability:rollback-on-error:1.0',
+                'urn:ietf:params:netconf:capability:startup:1.0',
+                'urn:ietf:params:netconf:capability:url:1.0?scheme=http,ftp,file,https,sftp',
+                'urn:ietf:params:netconf:capability:validate:1.0',
+                'urn:ietf:params:netconf:capability:xpath:1.0',
+                'urn:ietf:params:netconf:capability:notification:1.0',
+                'urn:liberouter:params:netconf:capability:power-control:1.0',
+                'urn:ietf:params:netconf:capability:interleave:1.0',
+                'urn:ietf:params:netconf:capability:with-defaults:1.0']
 
 class TestDefaultDevice(unittest.TestCase):
 

--- a/test/unit/operations/test_retrieve.py
+++ b/test/unit/operations/test_retrieve.py
@@ -6,6 +6,7 @@ import ncclient.manager
 import ncclient.transport
 from ncclient.xml_ import *
 from ncclient.operations import RaiseMode
+from ncclient.operations.errors import MissingCapabilityError
 from xml.etree import ElementTree
 import copy
 
@@ -31,6 +32,48 @@ class TestRetrieve(unittest.TestCase):
         self.assertEqual(call, xml)
 
     @patch('ncclient.operations.retrieve.RPC._request')
+    def test_get_with_defaults(self, mock_request):
+        session = ncclient.transport.SSHSession(self.device_handler)
+        session._server_capabilities = [':with-defaults']
+        obj = Get(session, self.device_handler, raise_mode=RaiseMode.ALL)
+        obj.request(with_defaults='report-all')
+
+        expected_xml = (
+            '<ns0:get xmlns:ns0="{base}" xmlns:ns1="{defaults}">'
+            '<ns1:with-defaults>report-all</ns1:with-defaults>'
+            '</ns0:get>'.format(
+                base=BASE_NS_1_0,
+                defaults=NETCONF_WITH_DEFAULTS_NS
+            )
+        )
+
+        call = mock_request.call_args_list[0][0][0]
+        call = ElementTree.tostring(call)
+        self.assertEqual(call, expected_xml)
+
+    @patch('ncclient.operations.retrieve.RPC._request')
+    def test_get_with_defaults_not_supported(self, mock_request):
+        session = ncclient.transport.SSHSession(self.device_handler)
+        session._server_capabilities = []
+        obj = Get(session, self.device_handler, raise_mode=RaiseMode.ALL)
+        with self.assertRaises(MissingCapabilityError):
+            obj.request(with_defaults='report-all')
+
+    @patch('ncclient.operations.retrieve.RPC._request')
+    def test_with_defaults_valid_options(self, mock_request):
+        session = ncclient.transport.SSHSession(self.device_handler)
+        session._server_capabilities = [':with-defaults']
+        obj = Get(session, self.device_handler, raise_mode=RaiseMode.ALL)
+
+        obj.request(with_defaults='explicit')
+        obj.request(with_defaults='report-all')
+        obj.request(with_defaults='report-all-tagged')
+        obj.request(with_defaults='trim')
+
+        with self.assertRaises(WithDefaultsError):
+            obj.request(with_defaults='invalid-option')
+
+    @patch('ncclient.operations.retrieve.RPC._request')
     def test_get_config(self, mock_request):
         session = ncclient.transport.SSHSession(self.device_handler)
         obj = GetConfig(session, self.device_handler, raise_mode=RaiseMode.ALL)
@@ -42,6 +85,37 @@ class TestRetrieve(unittest.TestCase):
         call = mock_request.call_args_list[0][0][0]
         call = ElementTree.tostring(call)
         self.assertEqual(call, xml)
+
+    @patch('ncclient.operations.retrieve.RPC._request')
+    def test_get_config_with_defaults(self, mock_request):
+        session = ncclient.transport.SSHSession(self.device_handler)
+        session._server_capabilities = [':with-defaults']
+        obj = GetConfig(session, self.device_handler, raise_mode=RaiseMode.ALL)
+        source = 'candidate'
+        obj.request(source, with_defaults='explicit')
+
+        expected_xml = (
+            '<ns0:get-config xmlns:ns0="{base}" xmlns:ns1="{defaults}">'
+            '<ns0:source><ns0:candidate /></ns0:source>'
+            '<ns1:with-defaults>explicit</ns1:with-defaults>'
+            '</ns0:get-config>'.format(
+                base=BASE_NS_1_0,
+                defaults=NETCONF_WITH_DEFAULTS_NS
+            )
+        )
+
+        call = mock_request.call_args_list[0][0][0]
+        call = ElementTree.tostring(call)
+        self.assertEqual(call, expected_xml)
+
+    @patch('ncclient.operations.retrieve.RPC._request')
+    def test_get_config_with_defaults_not_supported(self, mock_request):
+        session = ncclient.transport.SSHSession(self.device_handler)
+        session._server_capabilities = []
+        obj = GetConfig(session, self.device_handler, raise_mode=RaiseMode.ALL)
+        source = 'candidate'
+        with self.assertRaises(MissingCapabilityError):
+            obj.request(source, with_defaults='explicit')
 
     @patch('ncclient.operations.retrieve.RPC._request')
     def test_get_schema(self, mock_request):

--- a/test/unit/operations/test_retrieve.py
+++ b/test/unit/operations/test_retrieve.py
@@ -8,6 +8,7 @@ from ncclient.xml_ import *
 from ncclient.operations import RaiseMode
 from ncclient.operations.errors import MissingCapabilityError
 from xml.etree import ElementTree
+from lxml import etree
 import copy
 
 
@@ -38,18 +39,17 @@ class TestRetrieve(unittest.TestCase):
         obj = Get(session, self.device_handler, raise_mode=RaiseMode.ALL)
         obj.request(with_defaults='report-all')
 
-        expected_xml = (
-            '<ns0:get xmlns:ns0="{base}" xmlns:ns1="{defaults}">'
-            '<ns1:with-defaults>report-all</ns1:with-defaults>'
-            '</ns0:get>'.format(
+        expected_xml = etree.fromstring(
+            '<nc:get xmlns:nc="{base}">'
+            '<ns0:with-defaults xmlns:ns0="{defaults}">report-all</ns0:with-defaults>'
+            '</nc:get>'.format(
                 base=BASE_NS_1_0,
                 defaults=NETCONF_WITH_DEFAULTS_NS
             )
         )
 
         call = mock_request.call_args_list[0][0][0]
-        call = ElementTree.tostring(call)
-        self.assertEqual(call, expected_xml)
+        self.assertEqual(etree.tostring(call), etree.tostring(expected_xml))
 
     @patch('ncclient.operations.retrieve.RPC._request')
     def test_get_with_defaults_not_supported(self, mock_request):
@@ -94,19 +94,18 @@ class TestRetrieve(unittest.TestCase):
         source = 'candidate'
         obj.request(source, with_defaults='explicit')
 
-        expected_xml = (
-            '<ns0:get-config xmlns:ns0="{base}" xmlns:ns1="{defaults}">'
-            '<ns0:source><ns0:candidate /></ns0:source>'
-            '<ns1:with-defaults>explicit</ns1:with-defaults>'
-            '</ns0:get-config>'.format(
+        expected_xml = etree.fromstring(
+            '<nc:get-config xmlns:nc="{base}">'
+            '<nc:source><nc:candidate /></nc:source>'
+            '<ns0:with-defaults xmlns:ns0="{defaults}">explicit</ns0:with-defaults>'
+            '</nc:get-config>'.format(
                 base=BASE_NS_1_0,
                 defaults=NETCONF_WITH_DEFAULTS_NS
             )
         )
 
         call = mock_request.call_args_list[0][0][0]
-        call = ElementTree.tostring(call)
-        self.assertEqual(call, expected_xml)
+        self.assertEqual(etree.tostring(call), etree.tostring(expected_xml))
 
     @patch('ncclient.operations.retrieve.RPC._request')
     def test_get_config_with_defaults_not_supported(self, mock_request):

--- a/test/unit/operations/test_retrieve.py
+++ b/test/unit/operations/test_retrieve.py
@@ -56,8 +56,11 @@ class TestRetrieve(unittest.TestCase):
         session = ncclient.transport.SSHSession(self.device_handler)
         session._server_capabilities = []
         obj = Get(session, self.device_handler, raise_mode=RaiseMode.ALL)
-        with self.assertRaises(MissingCapabilityError):
-            obj.request(with_defaults='report-all')
+        self.assertRaises(
+            MissingCapabilityError,
+            obj.request,
+            with_defaults='report-all'
+        )
 
     @patch('ncclient.operations.retrieve.RPC._request')
     def test_with_defaults_valid_options(self, mock_request):
@@ -69,9 +72,11 @@ class TestRetrieve(unittest.TestCase):
         obj.request(with_defaults='report-all')
         obj.request(with_defaults='report-all-tagged')
         obj.request(with_defaults='trim')
-
-        with self.assertRaises(WithDefaultsError):
-            obj.request(with_defaults='invalid-option')
+        self.assertRaises(
+            WithDefaultsError,
+            obj.request,
+            with_defaults='invalid-option'
+        )
 
     @patch('ncclient.operations.retrieve.RPC._request')
     def test_get_config(self, mock_request):
@@ -113,8 +118,12 @@ class TestRetrieve(unittest.TestCase):
         session._server_capabilities = []
         obj = GetConfig(session, self.device_handler, raise_mode=RaiseMode.ALL)
         source = 'candidate'
-        with self.assertRaises(MissingCapabilityError):
-            obj.request(source, with_defaults='explicit')
+        self.assertRaises(
+            MissingCapabilityError,
+            obj.request,
+            source,
+            with_defaults='explicit'
+        )
 
     @patch('ncclient.operations.retrieve.RPC._request')
     def test_get_schema(self, mock_request):

--- a/test/unit/transport/test_ssh.py
+++ b/test/unit/transport/test_ssh.py
@@ -1,5 +1,5 @@
 import unittest
-from mock import patch
+from mock import MagicMock, patch
 from ncclient.transport.ssh import SSHSession
 from ncclient.transport import AuthenticationError, SessionCloseError
 import paramiko
@@ -118,7 +118,7 @@ class TestSSH(unittest.TestCase):
         mock_get_key.return_value = [key]
         device_handler = JunosDeviceHandler({'name': 'junos'})
         obj = SSHSession(device_handler)
-        obj._transport = paramiko.Transport(None)
+        obj._transport = paramiko.Transport(MagicMock())
         obj._auth('user', 'password', [], True, True)
         self.assertEqual(
             (mock_auth_public_key.call_args_list[0][0][1]).__repr__(),
@@ -132,7 +132,7 @@ class TestSSH(unittest.TestCase):
         mock_auth_public_key.side_effect = paramiko.ssh_exception.AuthenticationException
         device_handler = JunosDeviceHandler({'name': 'junos'})
         obj = SSHSession(device_handler)
-        obj._transport = paramiko.Transport(None)
+        obj._transport = paramiko.Transport(MagicMock())
         self.assertRaises(AuthenticationError,
             obj._auth,'user', None, [], True, False)
 
@@ -143,7 +143,7 @@ class TestSSH(unittest.TestCase):
         mock_get_key.return_value = key
         device_handler = JunosDeviceHandler({'name': 'junos'})
         obj = SSHSession(device_handler)
-        obj._transport = paramiko.Transport(None)
+        obj._transport = paramiko.Transport(MagicMock())
         obj._auth('user', 'password', ["key_file_name"], False, True)
         self.assertEqual(
             (mock_auth_public_key.call_args_list[0][0][1]).__repr__(),
@@ -156,7 +156,7 @@ class TestSSH(unittest.TestCase):
         mock_get_key.side_effect = paramiko.ssh_exception.PasswordRequiredException
         device_handler = JunosDeviceHandler({'name': 'junos'})
         obj = SSHSession(device_handler)
-        obj._transport = paramiko.Transport(None)
+        obj._transport = paramiko.Transport(MagicMock())
         self.assertRaises(AuthenticationError,
             obj._auth,'user', None, ["key_file_name"], False, True)
 
@@ -170,7 +170,7 @@ class TestSSH(unittest.TestCase):
         mock_is_file.return_value = True
         device_handler = JunosDeviceHandler({'name': 'junos'})
         obj = SSHSession(device_handler)
-        obj._transport = paramiko.Transport(None)
+        obj._transport = paramiko.Transport(MagicMock())
         obj._auth('user', 'password', [], False, True)
         self.assertEqual(
             (mock_auth_public_key.call_args_list[0][0][1]).__repr__(),
@@ -186,7 +186,7 @@ class TestSSH(unittest.TestCase):
         mock_get_key.side_effect = paramiko.ssh_exception.PasswordRequiredException
         device_handler = JunosDeviceHandler({'name': 'junos'})
         obj = SSHSession(device_handler)
-        obj._transport = paramiko.Transport(None)
+        obj._transport = paramiko.Transport(MagicMock())
         self.assertRaises(AuthenticationError,
 			              obj._auth,'user', None, [], False, True)
 
@@ -194,7 +194,7 @@ class TestSSH(unittest.TestCase):
     def test_auth_password(self, mock_auth_password):
         device_handler = JunosDeviceHandler({'name': 'junos'})
         obj = SSHSession(device_handler)
-        obj._transport = paramiko.Transport(None)
+        obj._transport = paramiko.Transport(MagicMock())
         obj._auth('user', 'password', [], False, True)
         self.assertEqual(
             mock_auth_password.call_args_list[0][0],
@@ -206,14 +206,14 @@ class TestSSH(unittest.TestCase):
         mock_auth_password.side_effect = Exception
         device_handler = JunosDeviceHandler({'name': 'junos'})
         obj = SSHSession(device_handler)
-        obj._transport = paramiko.Transport(None)
+        obj._transport = paramiko.Transport(MagicMock())
         self.assertRaises(AuthenticationError,
             obj._auth, 'user', 'password', [], False, True)
 
     def test_auth_no_methods_exception(self):
         device_handler = JunosDeviceHandler({'name': 'junos'})
         obj = SSHSession(device_handler)
-        obj._transport = paramiko.Transport(None)
+        obj._transport = paramiko.Transport(MagicMock())
         self.assertRaises(AuthenticationError,
             obj._auth,'user', None, [], False, False)
 
@@ -221,7 +221,7 @@ class TestSSH(unittest.TestCase):
     def test_close(self, mock_close):
         device_handler = JunosDeviceHandler({'name': 'junos'})
         obj = SSHSession(device_handler)
-        obj._transport = paramiko.Transport(None)
+        obj._transport = paramiko.Transport(MagicMock())
         obj._transport.active = True
         obj._connected = True
         obj.close()


### PR DESCRIPTION
RFC 6243 defines an optional "with-defaults" parameter for "get" and "get-config" requests that determines how a NETCONF server should handle retrieving default configuration values. This update adds support for this parameter.

- Added "with-defaults" support to Get and GetConfig
- Added the "with-defaults" capability to the default client
- Wrote tests for all of the new cases