### PR TITLE
Fix incorrect handling of RPC

### DIFF
--- a/ncclient/devices/csr.py
+++ b/ncclient/devices/csr.py
@@ -31,6 +31,3 @@ class CsrDeviceHandler(DefaultDeviceHandler):
         kwargs['allow_agent']   = False
         kwargs['look_for_keys'] = False
         kwargs['unknown_host_cb'] = csr_unknown_host_cb
-
-    def perform_qualify_check(self):
-        return False

--- a/ncclient/devices/iosxe.py
+++ b/ncclient/devices/iosxe.py
@@ -38,6 +38,3 @@ class IosxeDeviceHandler(DefaultDeviceHandler):
         kwargs['allow_agent']   = False
         kwargs['look_for_keys'] = False
         kwargs['unknown_host_cb'] = iosxe_unknown_host_cb
-
-    def perform_qualify_check(self):
-        return False

--- a/ncclient/operations/rpc.py
+++ b/ncclient/operations/rpc.py
@@ -211,8 +211,8 @@ class RPCReplyListener(SessionListener): # internal use
         if "message-id" not in attrs:
             # required attribute so raise OperationError
             raise OperationError("Could not find 'message-id' attribute in <rpc-reply>")
-        if key == "message-id":  # if we found msgid attr
-            id = attrs[key]  # get the msgid
+        else:
+            id = attrs["message-id"]  # get the msgid
             with self._lock:
                 try:
                     rpc = self._id2rpc[id]  # the corresponding rpc
@@ -224,7 +224,6 @@ class RPCReplyListener(SessionListener): # internal use
                 else:
                     # if no error delivering, can del the reference to the RPC
                     del self._id2rpc[id]
-                    break
 
     def errback(self, err):
         try:

--- a/ncclient/operations/rpc.py
+++ b/ncclient/operations/rpc.py
@@ -211,21 +211,20 @@ class RPCReplyListener(SessionListener): # internal use
         if "message-id" not in attrs:
             # required attribute so raise OperationError
             raise OperationError("Could not find 'message-id' attribute in <rpc-reply>")
-        for key in attrs:  # in the <rpc-reply> attributes
-            if key == "message-id":  # if we found msgid attr
-                id = attrs[key]  # get the msgid
-                with self._lock:
-                    try:
-                        rpc = self._id2rpc[id]  # the corresponding rpc
-                        logger.debug("Delivering to %r" % rpc)
-                        rpc.deliver_reply(raw)
-                    except KeyError:
-                        raise OperationError("Unknown 'message-id': %s" % id)
-                    # no catching other exceptions, fail loudly if must
-                    else:
-                        # if no error delivering, can del the reference to the RPC
-                        del self._id2rpc[id]
-                        break
+        if key == "message-id":  # if we found msgid attr
+            id = attrs[key]  # get the msgid
+            with self._lock:
+                try:
+                    rpc = self._id2rpc[id]  # the corresponding rpc
+                    logger.debug("Delivering to %r" % rpc)
+                    rpc.deliver_reply(raw)
+                except KeyError:
+                    raise OperationError("Unknown 'message-id': %s" % id)
+                # no catching other exceptions, fail loudly if must
+                else:
+                    # if no error delivering, can del the reference to the RPC
+                    del self._id2rpc[id]
+                    break
 
     def errback(self, err):
         try:

--- a/ncclient/operations/rpc.py
+++ b/ncclient/operations/rpc.py
@@ -208,23 +208,26 @@ class RPCReplyListener(SessionListener): # internal use
         if self._device_handler.perform_qualify_check():
             if tag != qualify("rpc-reply"):
                 return
-        for key in attrs: # in the <rpc-reply> attributes
-            if key == "message-id": # if we found msgid attr
-                id = attrs[key] # get the msgid
-                with self._lock:
-                    try:
-                        rpc = self._id2rpc[id] # the corresponding rpc
-                        logger.debug("Delivering to %r" % rpc)
-                        rpc.deliver_reply(raw)
-                    except KeyError:
-                        raise OperationError("Unknown 'message-id': %s" % id)
-                    # no catching other exceptions, fail loudly if must
-                    else:
-                        # if no error delivering, can del the reference to the RPC
-                        del self._id2rpc[id]
-                        break
-        else:
-            raise OperationError("Could not find 'message-id' attribute in <rpc-reply>")
+        for key in attrs:  # in the <rpc-reply> attributes
+            message_id = attrs.get("message-id")
+            if message_id is None:
+                # required attribute so raise OperationError
+                raise OperationError("Could not find 'message-id' attribute in <rpc-reply>")
+            else:
+                if key == "message-id":  # if we found msgid attr
+                    id = attrs[key]  # get the msgid
+                    with self._lock:
+                        try:
+                            rpc = self._id2rpc[id]  # the corresponding rpc
+                            logger.debug("Delivering to %r" % rpc)
+                            rpc.deliver_reply(raw)
+                        except KeyError:
+                            raise OperationError("Unknown 'message-id': %s" % id)
+                        # no catching other exceptions, fail loudly if must
+                        else:
+                            # if no error delivering, can del the reference to the RPC
+                            del self._id2rpc[id]
+                            break
 
     def errback(self, err):
         try:


### PR DESCRIPTION
Fixes issue #205 . A bad indented "else" was causing an issue with RPC's that did not have the "message-id" attribute. This fix removes that code and reworks the logic of handling the attributes.