### PR TITLE
Add rollback api for junos device

### DIFF
--- a/examples/juniper/rollback.py
+++ b/examples/juniper/rollback.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+
+from ncclient import manager
+
+
+def connect(host, port, user, password):
+    conn = manager.connect(host=host,
+            port=port,
+            username=user,
+            password=password,
+            timeout=10,
+            device_params = {'name':'junos'},
+            hostkey_verify=False)
+
+    rollback_config = conn.rollback(rollback=1)
+    print rollback_config.tostring
+
+if __name__ == '__main__':
+    connect('router', 830, 'netconf', 'juniper!')

--- a/ncclient/devices/junos.py
+++ b/ncclient/devices/junos.py
@@ -16,7 +16,7 @@ import re
 from lxml import etree
 from .default import DefaultDeviceHandler
 from ncclient.operations.third_party.juniper.rpc import GetConfiguration, LoadConfiguration, CompareConfiguration
-from ncclient.operations.third_party.juniper.rpc import ExecuteRpc, Command, Reboot, Halt, Commit
+from ncclient.operations.third_party.juniper.rpc import ExecuteRpc, Command, Reboot, Halt, Commit, Rollback
 from ncclient.operations.rpc import RPCError
 from ncclient.xml_ import to_ele
 
@@ -38,6 +38,7 @@ class JunosDeviceHandler(DefaultDeviceHandler):
         dict["reboot"] = Reboot
         dict["halt"] = Halt
         dict["commit"] = Commit
+        dict["rollback"] = Rollback
         return dict
 
     def perform_qualify_check(self):

--- a/ncclient/operations/third_party/juniper/rpc.py
+++ b/ncclient/operations/third_party/juniper/rpc.py
@@ -95,3 +95,8 @@ class Commit(RPC):
         if synchronize:
             sub_ele(node, "synchronize")
         return self._request(node)
+
+class Rollback(RPC):
+    def request(self, rollback=0):
+        node = new_ele('load-configuration', {'rollback':str(rollback)})
+        return self._request(node)

--- a/test/unit/devices/test_junos.py
+++ b/test/unit/devices/test_junos.py
@@ -75,6 +75,7 @@ class TestJunosDevice(unittest.TestCase):
         dict["reboot"] = Reboot
         dict["halt"] = Halt
         dict["commit"] = Commit
+        dict["rollback"] = Rollback
         self.assertEqual(dict, self.obj.add_additional_operations())
 
     def test_transform_reply(self):


### PR DESCRIPTION
Add support for JUNOS rollback configuration by adding
new `rollback` API.