### PR TITLE
Add cancel_commit to the manager

### DIFF
--- a/docs/source/operations.rst
+++ b/docs/source/operations.rst
@@ -75,6 +75,10 @@ Editing
     :members: request
     :show-inheritance:
 
+.. autoclass:: CancelCommit
+    :members: request
+    :show-inheritance:
+
 Locking
 ........
 

--- a/ncclient/manager.py
+++ b/ncclient/manager.py
@@ -38,6 +38,7 @@ OPERATIONS = {
     "validate": operations.Validate,
     "commit": operations.Commit,
     "discard_changes": operations.DiscardChanges,
+    "cancel_commit": operations.CancelCommit,
     "delete_config": operations.DeleteConfig,
     "lock": operations.Lock,
     "unlock": operations.Unlock,

--- a/ncclient/operations/__init__.py
+++ b/ncclient/operations/__init__.py
@@ -18,7 +18,7 @@ from ncclient.operations.rpc import RPC, RPCReply, RPCError, RaiseMode
 # rfc4741 ops
 
 from ncclient.operations.retrieve import Get, GetConfig, GetSchema, GetReply, Dispatch
-from ncclient.operations.edit import EditConfig, CopyConfig, DeleteConfig, Validate, Commit, DiscardChanges
+from ncclient.operations.edit import EditConfig, CopyConfig, DeleteConfig, Validate, Commit, DiscardChanges, CancelCommit
 from ncclient.operations.session import CloseSession, KillSession
 from ncclient.operations.lock import Lock, Unlock, LockContext
 from ncclient.operations.subscribe import CreateSubscription
@@ -41,6 +41,7 @@ __all__ = [
     'Validate',
     'Commit',
     'DiscardChanges',
+    'CancelCommit',
     'DeleteConfig',
     'Lock',
     'Unlock',

--- a/test/unit/operations/test_edit.py
+++ b/test/unit/operations/test_edit.py
@@ -164,3 +164,16 @@ class TestEdit(unittest.TestCase):
         call = mock_request.call_args_list[0][0][0]
         call = ElementTree.tostring(call)
         self.assertEqual(call, xml)
+
+    @patch('ncclient.operations.RPC._request')
+    def test_cancel_commit(self, mock_request):
+        session = ncclient.transport.SSHSession(self.device_handler)
+        session._server_capabilities = [':candidate', ":confirmed-commit"]
+        obj = CancelCommit(session, self.device_handler, raise_mode=RaiseMode.ALL)
+        obj.request(persist_id="foo")
+        node = new_ele("cancel-commit")
+        sub_ele(node, "persist-id").text = "foo"
+        xml = ElementTree.tostring(node)
+        call = mock_request.call_args_list[0][0][0]
+        call = ElementTree.tostring(call)
+        self.assertEqual(call, xml)


### PR DESCRIPTION
The RPC itself has already been implemented, it just wasn't attached
to the manager object.