### PR TITLE
Drop support for Python 2.6

### DIFF
--- a/README
+++ b/README
@@ -13,7 +13,7 @@ by [Leonidas Poulopoulos (@leopoul)](http://ncclient.org/ncclient/)
 **PyPI**: [https://pypi.python.org/pypi/ncclient](https://pypi.python.org/pypi/ncclient)
 
 #### Requirements:
-* Python >= 2.6 or Python3
+* Python 2.7 or Python 3.4+
 * setuptools 0.6+
 * Paramiko 1.7+
 * lxml 3.3.0+

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ by [Leonidas Poulopoulos (@leopoul)](http://ncclient.org)
 **PyPI**: [https://pypi.python.org/pypi/ncclient](https://pypi.python.org/pypi/ncclient)
 
 #### Requirements:
-* version >= Python 2.6 or Python3
+* Python 2.7 or Python 3.4+
 * setuptools 0.6+
 * Paramiko 1.7+
 * lxml 3.3.0+

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Github:
 Requirements:
 ^^^^^^^^^^^^^
 
--  Python >= 2.6 or Python 3
+-  Python 2.7 or Python 3.4+
 -  setuptools 0.6+
 -  Paramiko 1.7+
 -  lxml 3.3.0+

--- a/examples/nc01.py
+++ b/examples/nc01.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python2.6
+#! /usr/bin/env python
 #
 # Connect to the NETCONF server passed on the command line and
 # display their capabilities. This script and the following scripts

--- a/examples/nc02.py
+++ b/examples/nc02.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python2.6
+#! /usr/bin/env python
 #
 # Retrieve the running config from the NETCONF server passed on the
 # command line using get-config and write the XML configs to files.

--- a/examples/nc03.py
+++ b/examples/nc03.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python2.6 
+#! /usr/bin/env python
 #
 # Retrieve a portion selected by an XPATH expression from the running
 # config from the NETCONF server passed on the command line using

--- a/examples/nc04.py
+++ b/examples/nc04.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python2.6 
+#! /usr/bin/env python
 #
 # Create a new user to the running configuration using edit-config
 # and the test-option provided by the :validate capability.

--- a/examples/nc05.py
+++ b/examples/nc05.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python2.6 
+#! /usr/bin/env python
 #
 # Delete an existing user from the running configuration using
 # edit-config and the test-option provided by the :validate

--- a/examples/nc06.py
+++ b/examples/nc06.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python2.6 
+#! /usr/bin/env python
 #
 # Delete a list of existing users from the running configuration using
 # edit-config; protect the transaction using a lock.

--- a/examples/nc07.py
+++ b/examples/nc07.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python2.6 
+#! /usr/bin/env python
 #
 # Delete a list of existing users from the running configuration using
 # edit-config and the candidate datastore protected by a lock.

--- a/examples/nc08.py
+++ b/examples/nc08.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python2.6 
+#! /usr/bin/env python
 #
 # Configure an Interface: its description and make it active.
 # XML payload created with lxml/etree instead of a template

--- a/examples/nxosapi.py
+++ b/examples/nxosapi.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python2.6
+#! /usr/bin/env python
 #
 # Connect to the NETCONF server passed on the command line and
 # display their capabilities. This script and the following scripts

--- a/ncclient/__init__.py
+++ b/ncclient/__init__.py
@@ -16,8 +16,8 @@ __version__ = (0,5,3)
 
 import sys
 
-if sys.version_info < (2, 6):
-    raise RuntimeError('You need Python 2.6+ for this module.')
+if sys.version_info < (2, 7):
+    raise RuntimeError('You need Python 2.7+ for this module.')
 
 class NCClientError(Exception):
     "Base type for all NCClient errors"

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,8 @@ import sys
 import platform
 import codecs
 
-if sys.version_info[0] == 2 and sys.version_info[1] < 6:
-    print ("Sorry, Python < 2.6 is not supported")
+if sys.version_info.major == 2 and sys.version_info.minor < 7:
+    print ("Sorry, Python < 2.7 is not supported")
     exit()
 
 #parse requirements
@@ -45,11 +45,13 @@ setup(name='ncclient',
       license="Apache License 2.0",
       platforms=["Posix; OS X; Windows"],
       keywords=('NETCONF', 'NETCONF Python client', 'Juniper Optimization', 'Cisco NXOS Optimization'),
+      python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
       classifiers=[
           'Development Status :: 5 - Production/Stable',
-          'Programming Language :: Python :: 2.6',
           'Programming Language :: Python :: 2.7',
           'Programming Language :: Python :: 3.4',
+          'Programming Language :: Python :: 3.5',
+          'Programming Language :: Python :: 3.6',
           'Topic :: System :: Networking',
           'Intended Audience :: Developers',
           'Operating System :: OS Independent',


### PR DESCRIPTION
Fixes #228.

Also add `python_requires` to setup.py to help pip, and assume Python 3.4 is the min Python 3.x supported, as this is the lowest tested by Travis CI. It's also the lowest still supported CPython version.