### PR TITLE
Fix junos confirm-commit issue and check mode issue

### DIFF
--- a/ncclient/operations/third_party/juniper/rpc.py
+++ b/ncclient/operations/third_party/juniper/rpc.py
@@ -64,14 +64,14 @@ class Commit(RPC):
 
     DEPENDS = [':candidate']
 
-    def request(self, confirmed=False, timeout=None, comment=None, synchronize=False, at_time=None):
+    def request(self, confirmed=False, timeout=None, comment=None, synchronize=False, at_time=None, check=False):
         """Commit the candidate configuration as the device's new current configuration. Depends on the `:candidate` capability.
 
         A confirmed commit (i.e. if *confirmed* is `True`) is reverted if there is no followup commit within the *timeout* interval. If no timeout is specified the confirm timeout defaults to 600 seconds (10 minutes). A confirming commit may have the *confirmed* parameter but this is not required. Depends on the `:confirmed-commit` capability.
 
         *confirmed* whether this is a confirmed commit. Mutually exclusive with at_time.
 
-        *timeout* specifies the confirm timeout in seconds
+        *timeout* specifies the confirm timeout in minutes
 
         *comment* a string to comment the commit with. Review on the device using 'show system commit'
 
@@ -79,8 +79,10 @@ class Commit(RPC):
 
         *at_time* Mutually exclusive with confirmed. The time at which the commit should happen. Junos expects either of these two formats:
             A time value of the form hh:mm[:ss] (hours, minutes, and, optionally, seconds)
-            A date and time value of the form yyyy-mm-dd hh:mm[:ss] (year, month, date, hours, minutes, and, optionally, seconds)"""
-        node = new_ele("commit")
+            A date and time value of the form yyyy-mm-dd hh:mm[:ss] (year, month, date, hours, minutes, and, optionally, seconds)
+
+        *check* Verify the syntactic correctness of the candidate configuration"""
+        node = new_ele("commit-configuration")
         if confirmed and at_time is not None:
             raise NCClientError("'Commit confirmed' and 'commit at' are mutually exclusive.")
         if confirmed:
@@ -94,6 +96,8 @@ class Commit(RPC):
             sub_ele(node, "log").text = comment
         if synchronize:
             sub_ele(node, "synchronize")
+        if check:
+            sub_ele(node, "check")
         return self._request(node)
 
 class Rollback(RPC):

--- a/test/unit/operations/third_party/juniper/test_rpc.py
+++ b/test/unit/operations/third_party/juniper/test_rpc.py
@@ -203,7 +203,7 @@ class TestRPC(unittest.TestCase):
         session = ncclient.transport.SSHSession(device_handler)
         obj = Commit(session, device_handler, raise_mode=RaiseMode.ALL)
         obj.request(confirmed=True, comment="message", timeout="50")
-        node = new_ele("commit")
+        node = new_ele("commit-configuration")
         sub_ele(node, "confirmed")
         sub_ele(node, "confirm-timeout").text = "50"
         sub_ele(node, "log").text = "message"
@@ -221,7 +221,7 @@ class TestRPC(unittest.TestCase):
         session = ncclient.transport.SSHSession(device_handler)
         obj = Commit(session, device_handler, raise_mode=RaiseMode.ALL)
         obj.request()
-        node = new_ele("commit")
+        node = new_ele("commit-configuration")
         xml = ElementTree.tostring(node)
         call = mock_request.call_args_list[0][0][0]
         call = ElementTree.tostring(call)
@@ -236,7 +236,7 @@ class TestRPC(unittest.TestCase):
         session = ncclient.transport.SSHSession(device_handler)
         obj = Commit(session, device_handler, raise_mode=RaiseMode.ALL)
         obj.request(at_time="1111-11-11 00:00:00", synchronize=True)
-        node = new_ele("commit")
+        node = new_ele("commit-configuration")
         sub_ele(node, "at-time").text = "1111-11-11 00:00:00"
         sub_ele(node, "synchronize")
         xml = ElementTree.tostring(node)


### PR DESCRIPTION
Fixes #238

*  As per Juniper documentation the correct xml tag for commit rpc
   is `commit-configuration` and not `commit`.
*  Add support for `check` mode

Before in case commit is not issued after confirm commit.
Device logs show rollback happens immediately
```
user@junos# show | compare rollback ?
Possible completions:
  0                    2018-06-14 04:59:12 UTC by junos via netconf
  1                    2018-06-14 04:59:07 UTC by junos via netconf commit confirmed, rollback in 0mins
```

After the patch in this PR is applied
```
[edit]

Broadcast Message from user@junos
        (no tty) at 5:41 UTC...

Commit was not confirmed; automatic rollback complete.

user@junos# show | compare rollback ?
Possible completions:
  0                    2018-06-14 05:41:40 UTC by root via other
  1                    2018-06-14 05:39:39 UTC by user via netconf commit confirmed, rollback in 2mins
```