### PR TITLE
Fix junos confirm-commit issue (improved version)

### DIFF
--- a/ncclient/operations/third_party/juniper/rpc.py
+++ b/ncclient/operations/third_party/juniper/rpc.py
@@ -100,7 +100,7 @@ class Commit(RPC):
                 # http://ncclient.readthedocs.io/en/latest/manager.html#ncclient.manager.Manager.commit
                 # so need to convert the value in seconds to minutes.
                 timeout_int = int(timeout) if isinstance(timeout, str) else timeout
-                sub_ele(node, "confirm-timeout").text = str(math.ceil(timeout_int/60))
+                sub_ele(node, "confirm-timeout").text = str(int(math.ceil(timeout_int/60.0)))
         elif at_time is not None:
             sub_ele(node, "at-time").text = at_time
         if comment is not None:

--- a/ncclient/operations/third_party/juniper/rpc.py
+++ b/ncclient/operations/third_party/juniper/rpc.py
@@ -4,6 +4,8 @@ from ncclient.operations.rpc import RPC
 from ncclient.operations.rpc import RPCReply
 from ncclient.operations.rpc import RPCError
 from ncclient import NCClientError
+import math
+
 
 class GetConfiguration(RPC):
     def request(self, format='xml', filter=None):
@@ -71,7 +73,7 @@ class Commit(RPC):
 
         *confirmed* whether this is a confirmed commit. Mutually exclusive with at_time.
 
-        *timeout* specifies the confirm timeout in minutes
+        *timeout* specifies the confirm timeout in seconds
 
         *comment* a string to comment the commit with. Review on the device using 'show system commit'
 
@@ -82,14 +84,23 @@ class Commit(RPC):
             A date and time value of the form yyyy-mm-dd hh:mm[:ss] (year, month, date, hours, minutes, and, optionally, seconds)
 
         *check* Verify the syntactic correctness of the candidate configuration"""
-        node = new_ele("commit-configuration")
+        # NOTE: non netconf standard, Junos specific commit-configuration element, see
+        # https://www.juniper.net/documentation/en_US/junos/topics/reference/tag-summary/junos-xml-protocol-commit-configuration.html
+        node = new_ele_ns("commit-configuration", "")
         if confirmed and at_time is not None:
             raise NCClientError("'Commit confirmed' and 'commit at' are mutually exclusive.")
         if confirmed:
             self._assert(":confirmed-commit")
             sub_ele(node, "confirmed")
             if timeout is not None:
-                sub_ele(node, "confirm-timeout").text = timeout
+                # NOTE: For Junos, confirm-timeout has to be given in minutes:
+                # https://www.juniper.net/documentation/en_US/junos/topics/reference/tag-summary/junos-xml-protocol-commit-configuration.html
+                # but the netconf standard and ncclient library uses seconds:
+                # https://tools.ietf.org/html/rfc6241#section-8.4.5
+                # http://ncclient.readthedocs.io/en/latest/manager.html#ncclient.manager.Manager.commit
+                # so need to convert the value in seconds to minutes.
+                timeout_int = int(timeout) if isinstance(timeout, str) else timeout
+                sub_ele(node, "confirm-timeout").text = str(math.ceil(timeout_int/60))
         elif at_time is not None:
             sub_ele(node, "at-time").text = at_time
         if comment is not None:

--- a/test/unit/operations/third_party/juniper/test_rpc.py
+++ b/test/unit/operations/third_party/juniper/test_rpc.py
@@ -203,9 +203,10 @@ class TestRPC(unittest.TestCase):
         session = ncclient.transport.SSHSession(device_handler)
         obj = Commit(session, device_handler, raise_mode=RaiseMode.ALL)
         obj.request(confirmed=True, comment="message", timeout="50")
-        node = new_ele("commit")
+        node = new_ele_ns("commit-configuration", "")
         sub_ele(node, "confirmed")
-        sub_ele(node, "confirm-timeout").text = "50"
+        # confirm-timeout need to be provided in minutes for this Junos specific rpc
+        sub_ele(node, "confirm-timeout").text = "1"
         sub_ele(node, "log").text = "message"
         xml = ElementTree.tostring(node)
         call = mock_request.call_args_list[0][0][0]
@@ -221,7 +222,7 @@ class TestRPC(unittest.TestCase):
         session = ncclient.transport.SSHSession(device_handler)
         obj = Commit(session, device_handler, raise_mode=RaiseMode.ALL)
         obj.request()
-        node = new_ele("commit")
+        node = new_ele_ns("commit-configuration", "")
         xml = ElementTree.tostring(node)
         call = mock_request.call_args_list[0][0][0]
         call = ElementTree.tostring(call)
@@ -236,7 +237,7 @@ class TestRPC(unittest.TestCase):
         session = ncclient.transport.SSHSession(device_handler)
         obj = Commit(session, device_handler, raise_mode=RaiseMode.ALL)
         obj.request(at_time="1111-11-11 00:00:00", synchronize=True)
-        node = new_ele("commit")
+        node = new_ele_ns("commit-configuration", "")
         sub_ele(node, "at-time").text = "1111-11-11 00:00:00"
         sub_ele(node, "synchronize")
         xml = ElementTree.tostring(node)


### PR DESCRIPTION
Based on @ganeshrn fix (https://github.com/ncclient/ncclient/pull/239), but also clear the namespace for commit-configuration element (https://www.juniper.net/documentation/en_US/junos/topics/reference/tag-summary/junos-xml-protocol-commit-configuration.html) and update the corresponding unit tests.
I also tested it with a real Juniper SRX 300.