### PR TITLE
examples/juniper various improvements (issue #236 plus more):

### DIFF
--- a/examples/juniper/command-jnpr.py
+++ b/examples/juniper/command-jnpr.py
@@ -1,31 +1,37 @@
 #!/usr/bin/env python
+import logging
+import sys
 
 from ncclient import manager
 
 
 def connect(host, port, user, password):
     conn = manager.connect(host=host,
-            port=port,
-            username=user,
-            password=password,
-            timeout=10,
-            device_params = {'name':'junos'},
-            hostkey_verify=False)
+                           port=port,
+                           username=user,
+                           password=password,
+                           timeout=60,
+                           device_params={'name': 'junos'},
+                           hostkey_verify=False)
 
-    print 'show system users'
-    print '*' * 30
+    logging.info('show system users')
+    logging.info('*' * 30)
     result = conn.command(command='show system users', format='text')
-    print result.tostring
+    logging.info(result)
 
-    print 'show version'
-    print '*' * 30
+    logging.info('show version')
+    logging.info('*' * 30)
     result = conn.command('show version', format='text')
-    print result.xpath('output')[0].text
+    logging.info(result.xpath('output')[0].text)
 
-    print 'bgp summary'
-    print '*' * 30
+    logging.info('bgp summary')
+    logging.info('*' * 30)
     result = conn.command('show bgp summary')
-    print result.tostring
+    logging.info(result)
+
 
 if __name__ == '__main__':
+    LOG_FORMAT = '%(asctime)s %(levelname)s %(filename)s:%(lineno)d %(message)s'
+    logging.basicConfig(stream=sys.stdout, level=logging.INFO, format=LOG_FORMAT)
+
     connect('router', '22', 'netconf', 'juniper!')

--- a/examples/juniper/compare-config-jnpr.py
+++ b/examples/juniper/compare-config-jnpr.py
@@ -1,21 +1,25 @@
 #!/usr/bin/env python
+import logging
 
 from ncclient import manager
 from ncclient.xml_ import *
 
-import time
 
-def connect(host, port, user, password, source):
+def connect(host, port, user, password):
     conn = manager.connect(host=host,
-            port=port,
-            username=user,
-            password=password,
-            timeout=10,
-            device_params = {'name':'junos'},
-            hostkey_verify=False)
+                           port=port,
+                           username=user,
+                           password=password,
+                           timeout=60,
+                           device_params={'name': 'junos'},
+                           hostkey_verify=False)
 
-    compare_config = conn.compare_configuration(rollback=3)
-    print compare_config.tostring
+    compare_config_result = conn.compare_configuration(rollback=3)
+    logging.info(compare_config_result)
+
 
 if __name__ == '__main__':
-    connect('router', 830, 'netconf', 'juniper!', 'candidate')
+    LOG_FORMAT = '%(asctime)s %(levelname)s %(filename)s:%(lineno)d %(message)s'
+    logging.basicConfig(stream=sys.stdout, level=logging.INFO, format=LOG_FORMAT)
+
+    connect('router', 830, 'netconf', 'juniper!')

--- a/examples/juniper/delete-config-jnpr.py
+++ b/examples/juniper/delete-config-jnpr.py
@@ -1,33 +1,41 @@
 #!/usr/bin/env python
+import logging
 
 from ncclient import manager
 from ncclient.xml_ import *
 
-def connect(host, port, user, password, source):
-    conn = manager.connect(host=host,
-            port=port,
-            username=user,
-            password=password,
-            timeout=10,
-            device_params = {'name':'junos'},
-            hostkey_verify=False)
 
-    template = """<system><scripts><commit><file delete="delete"><name>test.slax</name></file></commit></scripts></system>"""
+def connect(host, port, user, password):
+    conn = manager.connect(host=host,
+                           port=port,
+                           username=user,
+                           password=password,
+                           timeout=60,
+                           device_params={'name': 'junos'},
+                           hostkey_verify=False)
+
+    template = """<system><scripts><commit>
+<file delete="delete"><name>test.slax</name></file>
+</commit></scripts></system>"""
 
     conn.lock()
     config = to_ele(template)
-    send_config = conn.load_configuration(config=config)
-    print send_config.tostring
+    load_config_result = conn.load_configuration(config=config)
+    logging.info(load_config_result)
 
-    check_config = conn.validate()
-    print check_config.tostring
+    validate_result = conn.validate()
+    logging.info(validate_result)
 
-    compare_config = conn.compare_configuration()
-    print compare_config.tostring
+    compare_config_result = conn.compare_configuration()
+    logging.info(compare_config_result)
 
     conn.commit()
     conn.unlock()
     conn.close_session()
 
+
 if __name__ == '__main__':
-    connect('router', 830, 'netconf', 'juniper!', 'candidate')
+    LOG_FORMAT = '%(asctime)s %(levelname)s %(filename)s:%(lineno)d %(message)s'
+    logging.basicConfig(stream=sys.stdout, level=logging.INFO, format=LOG_FORMAT)
+
+    connect('router', 830, 'netconf', 'juniper!')

--- a/examples/juniper/edit-config-jnpr-json.py
+++ b/examples/juniper/edit-config-jnpr-json.py
@@ -1,20 +1,26 @@
 #!/usr/bin/env python
-
 import json
+import logging
+import sys
 
 from ncclient import manager
 
-def connect(host, user, password):
+
+def connect(host, port, user, password):
     conn = manager.connect(host=host,
-            username=user,
-            password=password,
-            timeout=10,
-            device_params = {'name':'junos'},
-            hostkey_verify=False)
+                           port=port,
+                           username=user,
+                           password=password,
+                           timeout=60,
+                           device_params={'name': 'junos'},
+                           hostkey_verify=False)
 
     conn.lock()
 
     # configuration as a json encoded string
+    # TODO: this example (and possibly the ncclient library implementation?) is broken!
+    # class LoadConfiguration in operations/third_party/juniper/rpc.py would expect 'configuration-json' element to be
+    # used. Changing "configuration" to "configuration-json" in the 2 occasions below: still does not work!
     location = """
     {
         "configuration": {
@@ -32,18 +38,22 @@ def connect(host, user, password):
     config_json['configuration']['system']['location']['rack'] = "1117"
     config = json.dumps(config_json)
 
-    send_config = conn.load_configuration(format='json', config=config)
-    print send_config.tostring
+    load_config_result = conn.load_configuration(format='json', config=config)
+    logging.info(load_config_result)
 
-    check_config = conn.validate()
-    print check_config.tostring
+    validate_result = conn.validate()
+    logging.info(validate_result)
 
-    compare_config = conn.compare_configuration()
-    print compare_config.tostring
+    compare_config_result = conn.compare_configuration()
+    logging.info(compare_config_result)
 
     conn.commit()
     conn.unlock()
     conn.close_session()
 
+
 if __name__ == '__main__':
-    connect('router', 'netconf', 'juniper!')
+    LOG_FORMAT = '%(asctime)s %(levelname)s %(filename)s:%(lineno)d %(message)s'
+    logging.basicConfig(stream=sys.stdout, level=logging.INFO, format=LOG_FORMAT)
+
+    connect('router', '22', 'netconf', 'juniper!')

--- a/examples/juniper/edit-config-jnpr-set.py
+++ b/examples/juniper/edit-config-jnpr-set.py
@@ -1,19 +1,25 @@
 #!/usr/bin/env python
+import sys
+
+import logging
 
 from ncclient import manager
 
-def connect(host, user, password):
+
+def connect(host, port, user, password):
     conn = manager.connect(host=host,
-            username=user,
-            password=password,
-            timeout=10,
-            device_params = {'name':'junos'},
-            hostkey_verify=False)
+                           port=port,
+                           username=user,
+                           password=password,
+                           timeout=60,
+                           device_params={'name': 'junos'},
+                           hostkey_verify=False)
 
     conn.lock()
 
     # configuration as a string
-    send_config = conn.load_configuration(action='set', config='set system host-name foo')
+    load_config_result = conn.load_configuration(action='set', config='set system host-name foo')
+    logging.info(load_config_result)
 
     # configuration as a list
     location = []
@@ -21,18 +27,22 @@ def connect(host, user, password):
     location.append('set system location floor 15')
     location.append('set system location rack 1117')
 
-    send_config = conn.load_configuration(action='set', config=location)
-    print send_config.tostring
+    load_config_result = conn.load_configuration(action='set', config=location)
+    logging.info(load_config_result)
 
-    check_config = conn.validate()
-    print check_config.tostring
+    validate_result = conn.validate()
+    logging.info(validate_result)
 
-    compare_config = conn.compare_configuration()
-    print compare_config.tostring
+    compare_config_result = conn.compare_configuration()
+    logging.info(compare_config_result)
 
     conn.commit()
     conn.unlock()
     conn.close_session()
 
+
 if __name__ == '__main__':
-    connect('router', 'netconf', 'juniper!')
+    LOG_FORMAT = '%(asctime)s %(levelname)s %(filename)s:%(lineno)d %(message)s'
+    logging.basicConfig(stream=sys.stdout, level=logging.INFO, format=LOG_FORMAT)
+
+    connect('router', '22', 'netconf', 'juniper!')

--- a/examples/juniper/edit-config-jnpr-text.py
+++ b/examples/juniper/edit-config-jnpr-text.py
@@ -1,14 +1,18 @@
 #!/usr/bin/env python
+import logging
+import sys
 
 from ncclient import manager
 
-def connect(host, user, password):
+
+def connect(host, port, user, password):
     conn = manager.connect(host=host,
-            username=user,
-            password=password,
-            timeout=10,
-            device_params = {'name':'junos'},
-            hostkey_verify=False)
+                           port=port,
+                           username=user,
+                           password=password,
+                           timeout=60,
+                           device_params={'name': 'junos'},
+                           hostkey_verify=False)
 
     conn.lock()
 
@@ -25,27 +29,30 @@ def connect(host, user, password):
     }
     """
 
-    send_config = conn.load_configuration(format='text', config=location)
-    print send_config.tostring
+    load_config_result = conn.load_configuration(format='text', config=location)
+    logging.info(load_config_result)
 
     # configuration as an argument
-    send_config = conn.load_configuration(format='text',
-            config="""
-            system {
-                host-name %s;
-            }
-            """ % (new_host_name))
-    print send_config.tostring
+    load_config_result = conn.load_configuration(format='text', config="""
+    system {
+        host-name %s;
+    }
+    """ % new_host_name)
+    logging.info(load_config_result)
 
-    check_config = conn.validate()
-    print check_config.tostring
+    validate_result = conn.validate()
+    logging.info(validate_result)
 
-    compare_config = conn.compare_configuration()
-    print compare_config.tostring
+    compare_config_result = conn.compare_configuration()
+    logging.info(compare_config_result)
 
     conn.commit()
     conn.unlock()
     conn.close_session()
 
+
 if __name__ == '__main__':
-    connect('router', 'netconf', 'juniper!')
+    LOG_FORMAT = '%(asctime)s %(levelname)s %(filename)s:%(lineno)d %(message)s'
+    logging.basicConfig(stream=sys.stdout, level=logging.INFO, format=LOG_FORMAT)
+
+    connect('router', '22', 'netconf', 'juniper!')

--- a/examples/juniper/edit-config-jnpr.py
+++ b/examples/juniper/edit-config-jnpr.py
@@ -1,50 +1,55 @@
 #!/usr/bin/env python
+import logging
+import time
 
 from ncclient import manager
 from ncclient.xml_ import *
 
-import time
 
 def connect(host, port, user, password, source):
     conn = manager.connect(host=host,
-            port=port,
-            username=user,
-            password=password,
-            timeout=10,
-            device_params = {'name':'junos'},
-            hostkey_verify=False)
+                           port=port,
+                           username=user,
+                           password=password,
+                           timeout=60,
+                           device_params={'name': 'junos'},
+                           hostkey_verify=False)
 
-    print 'locking configuration'
-    lock = conn.lock()
+    logging.info('locking configuration')
+    lock_result = conn.lock()
+    logging.info(lock_result)
 
     # build configuration element
     config = new_ele('system')
     sub_ele(config, 'host-name').text = 'foo'
     sub_ele(config, 'domain-name').text = 'bar'
 
-    send_config = conn.load_configuration(config=config)
-    print send_config.tostring
+    load_config_result = conn.load_configuration(config=config)
+    logging.info(load_config_result)
 
-    check_config = conn.validate()
-    print check_config.tostring
+    validate_result = conn.validate()
+    logging.info(validate_result)
 
-    compare_config = conn.compare_configuration()
-    print compare_config.tostring
+    compare_config_result = conn.compare_configuration()
+    logging.info(compare_config_result)
 
-    print 'commit confirmed 300'
-    #commit_config = conn.commit(confirmed=True, timeout='300')
-    commit_config = conn.commit()
-    print commit_config.tostring
+    logging.info('commit confirmed')
+    commit_config = conn.commit(confirmed=True, timeout='300')
+    logging.info(commit_config)
 
-    print 'sleeping for 5 sec...'
+    logging.info('sleeping for 5 sec...')
     time.sleep(5)
 
-    discard_changes = conn.discard_changes()
-    print discard_changes.tostring
+    discard_changes_result = conn.discard_changes()
+    logging.info(discard_changes_result)
 
-    print 'unlocking configuration'
-    unlock = conn.unlock()
-    print unlock.tostring
+    logging.info('unlocking configuration')
+    unlock_result = conn.unlock()
+    logging.info(unlock_result)
+
 
 if __name__ == '__main__':
+    LOG_FORMAT = '%(asctime)s %(levelname)s %(filename)s:%(lineno)d %(message)s'
+    logging.basicConfig(stream=sys.stdout, level=logging.INFO, format=LOG_FORMAT)
+
     connect('router', 830, 'netconf', 'juniper!', 'candidate')

--- a/examples/juniper/edit-config-std.py
+++ b/examples/juniper/edit-config-std.py
@@ -1,15 +1,19 @@
 #!/usr/bin/env python
+import logging
+import sys
 
 from ncclient import manager
 from ncclient.xml_ import new_ele, sub_ele
 
-def connect(host, user, password):
+
+def connect(host, port, user, password):
     conn = manager.connect(host=host,
-            username=user,
-            password=password,
-            timeout=10,
-            device_params = {'name':'junos'},
-            hostkey_verify=False)
+                           port=port,
+                           username=user,
+                           password=password,
+                           timeout=60,
+                           device_params={'name': 'junos'},
+                           hostkey_verify=False)
 
     conn.lock()
 
@@ -21,18 +25,22 @@ def connect(host, user, password):
     sub_ele(location, 'floor').text = "5"
     sub_ele(location, 'rack').text = "27"
 
-    send_config = conn.edit_config(config=root)
-    print send_config.tostring
+    edit_config_result = conn.edit_config(config=root)
+    logging.info(edit_config_result)
 
-    check_config = conn.validate()
-    print check_config.tostring
+    validate_result = conn.validate()
+    logging.info(validate_result)
 
-    compare_config = conn.compare_configuration()
-    print compare_config.tostring
+    compare_config_result = conn.compare_configuration()
+    logging.info(compare_config_result)
 
     conn.commit()
     conn.unlock()
     conn.close_session()
 
+
 if __name__ == '__main__':
-    connect('router', 'netconf', 'juniper!')
+    LOG_FORMAT = '%(asctime)s %(levelname)s %(filename)s:%(lineno)d %(message)s'
+    logging.basicConfig(stream=sys.stdout, level=logging.INFO, format=LOG_FORMAT)
+
+    connect('router', '22', 'netconf', 'juniper!')

--- a/examples/juniper/edit-config-text-std.py
+++ b/examples/juniper/edit-config-text-std.py
@@ -1,14 +1,18 @@
 #!/usr/bin/env python
+import logging
+import sys
 
 from ncclient import manager
 
-def connect(host, user, password):
+
+def connect(host, port, user, password):
     conn = manager.connect(host=host,
-            username=user,
-            password=password,
-            timeout=10,
-            device_params = {'name':'junos'},
-            hostkey_verify=False)
+                           port=port,
+                           username=user,
+                           password=password,
+                           timeout=60,
+                           device_params={'name': 'junos'},
+                           hostkey_verify=False)
 
     conn.lock()
 
@@ -19,18 +23,23 @@ def connect(host, user, password):
     }
     """
 
-    send_config = conn.edit_config(format='text', config=host_name)
-    print send_config.tostring
+    edit_config_result = conn.edit_config(format='text', config=host_name)
+    logging.info(edit_config_result)
 
-    check_config = conn.validate()
-    print check_config.tostring
+    validate_result = conn.validate()
+    logging.info(validate_result)
 
-    compare_config = conn.compare_configuration()
-    print compare_config.tostring
+    compare_config_result = conn.compare_configuration()
+    logging.info(compare_config_result)
 
     conn.commit()
     conn.unlock()
     conn.close_session()
 
+
 if __name__ == '__main__':
-    connect('router', 'netconf', 'juniper!')
+    LOG_FORMAT = '%(asctime)s %(levelname)s %(filename)s:%(lineno)d %(message)s'
+    logging.basicConfig(stream=sys.stdout, level=logging.INFO, format=LOG_FORMAT)
+
+    connect('router', '22', 'netconf', 'juniper!')
+

--- a/examples/juniper/execute-async-rpc.py
+++ b/examples/juniper/execute-async-rpc.py
@@ -1,3 +1,5 @@
+import logging
+
 from ncclient import manager
 from ncclient.xml_ import *
 import time
@@ -9,7 +11,7 @@ def connect(host, port, user, password):
                            port=port,
                            username=user,
                            password=password,
-                           timeout=10,
+                           timeout=60,
                            device_params={'name': 'junos'},
                            hostkey_verify=False)
 
@@ -24,15 +26,18 @@ def connect(host, port, user, password):
 
     # for demo purposes, we just wait for the result 
     while not obj.event.is_set():
-        print('waiting for answer ...')
+        logging.info('waiting for answer ...')
         time.sleep(.3)
 
     result = NCElement(obj.reply,
                        junos_dev_handler.transform_reply()
                        ).remove_namespaces(obj.reply.xml)
 
-    print 'Hostname: ', result.findtext('.//host-name')
+    logging.info('Hostname: %s', result.findtext('.//host-name'))
 
 
 if __name__ == '__main__':
+    LOG_FORMAT = '%(asctime)s %(levelname)s %(filename)s:%(lineno)d %(message)s'
+    logging.basicConfig(stream=sys.stdout, level=logging.INFO, format=LOG_FORMAT)
+
     connect('router', 830, 'netconf', 'juniper!')

--- a/examples/juniper/execute-rpc-string.py
+++ b/examples/juniper/execute-rpc-string.py
@@ -1,16 +1,18 @@
 #!/usr/bin/env python
+import logging
 
 from ncclient import manager
 from ncclient.xml_ import *
 
-def connect(host, port, user, password, source):
+
+def connect(host, port, user, password):
     conn = manager.connect(host=host,
-            port=port,
-            username=user,
-            password=password,
-            timeout=10,
-            device_params = {'name':'junos'},
-            hostkey_verify=False)
+                           port=port,
+                           username=user,
+                           password=password,
+                           timeout=60,
+                           device_params={'name': 'junos'},
+                           hostkey_verify=False)
 
     rpc = """
     <get-chassis-inventory>
@@ -18,9 +20,11 @@ def connect(host, port, user, password, source):
     </get-chassis-inventory>"""
 
     result = conn.rpc(rpc)
-    print 'Chassis serial-number:', result.xpath('//chassis-inventory/chassis/serial-number')[0].text
-
+    logging.info('Chassis serial-number: %s', result.xpath('//chassis-inventory/chassis/serial-number')[0].text)
 
 
 if __name__ == '__main__':
-    connect('router', 830, 'netconf', 'juniper!', 'candidate')
+    LOG_FORMAT = '%(asctime)s %(levelname)s %(filename)s:%(lineno)d %(message)s'
+    logging.basicConfig(stream=sys.stdout, level=logging.INFO, format=LOG_FORMAT)
+
+    connect('router', 830, 'netconf', 'juniper!')

--- a/examples/juniper/execute-rpc.py
+++ b/examples/juniper/execute-rpc.py
@@ -1,23 +1,27 @@
 #!/usr/bin/env python
+import logging
 
 from ncclient import manager
 from ncclient.xml_ import *
 
-import time
 
-def connect(host, port, user, password, source):
+def connect(host, port, user, password):
     conn = manager.connect(host=host,
-            port=port,
-            username=user,
-            password=password,
-            timeout=10,
-            device_params = {'name':'junos'},
-            hostkey_verify=False)
+                           port=port,
+                           username=user,
+                           password=password,
+                           timeout=60,
+                           device_params={'name': 'junos'},
+                           hostkey_verify=False)
 
     rpc = new_ele('get-software-information')
 
     result = conn.rpc(rpc)
-    print 'Hostname:', result.xpath('//software-information/host-name')[0].text
+    logging.info('Hostname: %s', result.xpath('//software-information/host-name')[0].text)
+
 
 if __name__ == '__main__':
-    connect('router', 830, 'netconf', 'juniper!', 'candidate')
+    LOG_FORMAT = '%(asctime)s %(levelname)s %(filename)s:%(lineno)d %(message)s'
+    logging.basicConfig(stream=sys.stdout, level=logging.INFO, format=LOG_FORMAT)
+
+    connect('router', 830, 'netconf', 'juniper!')

--- a/examples/juniper/get-configuration-jnpr.py
+++ b/examples/juniper/get-configuration-jnpr.py
@@ -1,50 +1,55 @@
 #!/usr/bin/env python
 
 import json
+import logging
 
 from ncclient import manager
 from ncclient.xml_ import *
 
-def connect(host, port, user, password, source):
+
+def connect(host, port, user, password):
     conn = manager.connect(host=host,
-            port=port,
-            username=user,
-            password=password,
-            timeout=10,
-            device_params = {'name':'junos'},
-            hostkey_verify=False)
+                           port=port,
+                           username=user,
+                           password=password,
+                           timeout=60,
+                           device_params={'name': 'junos'},
+                           hostkey_verify=False)
 
     result_xml = conn.get_configuration(format='xml')
-    print result_xml.tostring
+    logging.info(result_xml)
 
     result_json = conn.get_configuration(format='json')
     payload = json.loads(result_json.xpath('.')[0].text)
-    print(payload['configuration']['system']['services'])
+    logging.info(payload)
+    logging.info(payload['configuration'][0]['system'][0]['services'])
 
     result_text = conn.get_configuration(format='text')
-    print result_text.xpath('configuration-text')[0].text
+    logging.info(result_text.xpath('configuration-text')[0].text)
 
-    print 'Version'
-    print '*' * 30
-    print result_xml.xpath('configuration/version')[0].text
+    logging.info('Version')
+    logging.info('*' * 30)
+    logging.info(result_xml.xpath('configuration/version')[0].text)
 
-    
     config_filter = new_ele('configuration')
     system_ele = sub_ele(config_filter, 'system')
     sub_ele(system_ele, 'login')
 
     result_filter = conn.get_configuration(format='xml', filter=config_filter)
-    print result_filter.tostring
+    logging.info(result_filter)
 
-    print 'Configured Interfaces...'
+    logging.info('Configured Interfaces...')
     interfaces = result_xml.xpath('configuration/interfaces/interface')
     for i in interfaces:
         interface = i.xpath('name')[0].text
         ip = []
-        for i in i.xpath('unit/family/inet/address/name'):
-            ip.append(i.text)
-        print ' ', interface, ip
+        for name in i.xpath('unit/family/inet/address/name'):
+            ip.append(name.text)
+        logging.info(' %s %s', interface, ip)
 
 
 if __name__ == '__main__':
-    connect('router', 830, 'netconf', 'juniper!', 'candidate')
+    LOG_FORMAT = '%(asctime)s %(levelname)s %(filename)s:%(lineno)d %(message)s'
+    logging.basicConfig(stream=sys.stdout, level=logging.INFO, format=LOG_FORMAT)
+
+    connect('router', 830, 'netconf', 'juniper!')

--- a/examples/juniper/get-configuration-matching.py
+++ b/examples/juniper/get-configuration-matching.py
@@ -1,44 +1,49 @@
 #!/usr/bin/env python
+import logging
+import sys
 
 from ncclient import manager
 
 
 def connect(host, port, user, password, source):
     conn = manager.connect(host=host,
-            port=port,
-            username=user,
-            password=password,
-            timeout=10,
-            device_params = {'name':'junos'},
-            hostkey_verify=False)
+                           port=port,
+                           username=user,
+                           password=password,
+                           timeout=60,
+                           device_params={'name': 'junos'},
+                           hostkey_verify=False)
 
     result_xml = conn.get_configuration(format='xml')
 
-    # xpath starts-with
+    logging.info("xpath starts-with")
     ge_configs = result_xml.xpath('configuration/interfaces/interface/name[starts-with(text(), "ge-")]')
     for i in ge_configs:
-        print i.tag, i.text
+        logging.info("%s %s", i.tag, i.text)
 
-    # xpath re:match
+    logging.info("xpath re:match")
     ge_configs = result_xml.xpath('configuration/interfaces/interface/name[re:match(text(), "ge")]')
     for i in ge_configs:
-        print i.tag, i.text
+        logging.info("%s %s", i.tag, i.text)
 
-    # xpath contains
+    logging.info("xpath contains")
     ge_configs = result_xml.xpath('configuration/interfaces/interface/name[contains(text(), "ge-")]')
     for i in ge_configs:
-        print i.tag, i.text
+        logging.info("%s %s", i.tag, i.text)
 
-    # xpath match on text
+    logging.info("xpath match on text")
     ge_configs = result_xml.xpath('configuration/interfaces/interface/name[text()="ge-0/0/0"]')
     for i in ge_configs:
-        print i.tag, i.text
+        logging.info("%s %s", i.tag, i.text)
 
-    # xpath match on text - alternative (wildcards not permitted)
+    logging.info("xpath match on text - alternative (wildcards not permitted)")
     ge_configs = result_xml.xpath('configuration/interfaces/interface[name="ge-0/0/0"]')
     for i in ge_configs:
-        print i.xpath('name')[0].tag, i.xpath('name')[0].text
+        logging.info("%s %s", i.xpath('name')[0].tag, i.xpath('name')[0].text)
 
 
 if __name__ == '__main__':
+    LOG_FORMAT = '%(asctime)s %(levelname)s %(filename)s:%(lineno)d %(message)s'
+    logging.basicConfig(stream=sys.stdout, level=logging.INFO, format=LOG_FORMAT)
+
     connect('router', 830, 'netconf', 'juniper!', 'candidate')

--- a/examples/juniper/get-interface-status.py
+++ b/examples/juniper/get-interface-status.py
@@ -1,17 +1,20 @@
 #!/usr/bin/env python
 # Python script to fetch interface name and their operation status
+import sys
+
+import logging
 
 from ncclient import manager
 
 
 def connect(host, port, user, password):
     conn = manager.connect(host=host,
-            port=port,
-            username=user,
-            password=password,
-            timeout=10,
-            device_params = {'name':'junos'},
-            hostkey_verify=False)
+                           port=port,
+                           username=user,
+                           password=password,
+                           timeout=60,
+                           device_params={'name': 'junos'},
+                           hostkey_verify=False)
 
     rpc = "<get-interface-information><terse/></get-interface-information>"
     response = conn.rpc(rpc)
@@ -20,7 +23,12 @@ def connect(host, port, user, password):
     for name, status in zip(interface_name, interface_status):
         name = name.text.split('\n')[1]
         status = status.text.split('\n')[1]
-        print ("{}-{}".format(name, status))
+        logging.info("{} - {}".format(name, status))
+
 
 if __name__ == '__main__':
+    LOG_FORMAT = '%(asctime)s %(levelname)s %(filename)s:%(lineno)d %(message)s'
+    logging.basicConfig(stream=sys.stdout, level=logging.INFO, format=LOG_FORMAT)
+
     connect('router', 830, 'netconf', 'juniper!')
+

--- a/examples/juniper/get-inventory.py
+++ b/examples/juniper/get-inventory.py
@@ -1,20 +1,26 @@
 #!/usr/bin/env python
+import logging
+import sys
 
 from ncclient import manager
 
+
 def connect(host, port, user, password):
     conn = manager.connect(host=host,
-            port=port,
-            username=user,
-            password=password,
-            timeout=10,
-            device_params = {'name':'junos'},
-            hostkey_verify=False)
-
+                           port=port,
+                           username=user,
+                           password=password,
+                           timeout=60,
+                           device_params={'name': 'junos'},
+                           hostkey_verify=False)
 
     result = conn.get_chassis_inventory()
-    print "Chassis:", result.xpath('//chassis/description')[0].text
-    print "Chassis Serial-Number:", result.xpath('//chassis/serial-number')[0].text
+    logging.info("Chassis: %s", result.xpath('//chassis/description')[0].text)
+    logging.info("Chassis Serial-Number: %s", result.xpath('//chassis/serial-number')[0].text)
+
 
 if __name__ == '__main__':
+    LOG_FORMAT = '%(asctime)s %(levelname)s %(filename)s:%(lineno)d %(message)s'
+    logging.basicConfig(stream=sys.stdout, level=logging.INFO, format=LOG_FORMAT)
+
     connect('router', 830, 'netconf', 'juniper!')

--- a/examples/juniper/get-session-params.py
+++ b/examples/juniper/get-session-params.py
@@ -1,33 +1,38 @@
 #!/usr/bin/env python
+import logging
+import sys
 
 from ncclient import manager
 from ncclient.transport import errors
 
 
-def connect(host, port, user, password, source):
+def connect(host, port, user, password):
     try:
         conn = manager.connect(host=host,
-                port=port,
-                username=user,
-                password=password,
-                timeout=10,
-                device_params = {'name':'junos'},
-            hostkey_verify=False)
+                               port=port,
+                               username=user,
+                               password=password,
+                               timeout=60,
+                               device_params={'name': 'junos'},
+                               hostkey_verify=False)
 
-        print 'connected:', conn.connected, ' .... to host', host, 'on port:', port
-        print 'session-id:', conn.session_id
-        print 'client capabilities:'
+        logging.info('connected: %s ... to host %s on port %s', conn.connected, host, port)
+        logging.info('session-id %s:', conn.session_id)
+        logging.info('client capabilities:')
         for i in conn.client_capabilities:
-            print ' ', i
-        print 'server capabilities:'
+            logging.info(' %s', i)
+        logging.info('server capabilities:')
         for i in conn.server_capabilities:
-            print ' ', i
+            logging.info(' %s', i)
         conn.close_session()
     except errors.SSHError:
-        print 'Unable to connect to host:', host, 'on port:', port
+        logging.exception('Unable to connect to host: %s on port %s', host, port)
 
 
 if __name__ == '__main__':
-    connect('router', 830, 'netconf', 'juniper!', 'candidate')
-    connect('router', 831, 'netconf', 'juniper!', 'candidate')
-    connect('router', 830, 'netconf', 'juniper!', 'candidate')
+    LOG_FORMAT = '%(asctime)s %(levelname)s %(filename)s:%(lineno)d %(message)s'
+    logging.basicConfig(stream=sys.stdout, level=logging.INFO, format=LOG_FORMAT)
+
+    connect('router', 830, 'netconf', 'juniper!')
+    connect('router', 831, 'netconf', 'juniper!')
+    connect('router', 830, 'netconf', 'juniper!')

--- a/examples/juniper/get-xnm-information.py
+++ b/examples/juniper/get-xnm-information.py
@@ -1,16 +1,23 @@
 #!/usr/bin/env python
+import logging
+import os
 
 from ncclient import manager
 from ncclient.xml_ import *
 
-def connect(host, port, user, password, source):
+
+def connect(host, port, user, password):
     conn = manager.connect(host=host,
-            port=port,
-            username=user,
-            password=password,
-            timeout=600,
-            device_params = {'name':'junos'},
-            hostkey_verify=False)
+                           port=port,
+                           username=user,
+                           password=password,
+                           timeout=1800,
+                           device_params={'name': 'junos'},
+                           hostkey_verify=False)
+
+    # https://www.juniper.net/documentation/en_US/junos/topics/task/operational/junos-xml-protocol-requesting-xml-schema.html
+    logging.info("Requesting an XML Schema for the Configuration Hierarchy")
+    logging.info("This may take several (even 10+) minutes")
 
     rpc = """
     <get-xnm-information>
@@ -19,11 +26,14 @@ def connect(host, port, user, password, source):
     </get-xnm-information>"""
 
     result = conn.rpc(rpc)
-    fh = open('schema.txt', 'w')
-    fh.write(result.tostring)
-    fh.close()
-
+    with open('schema.txt', 'w') as fh:
+        # Note: using NCElement's __str__() for python version independent conversion to string
+        fh.write(str(result))
+        logging.info('schema.txt is written to directory %s', os.getcwd())
 
 
 if __name__ == '__main__':
-    connect('router', 830, 'netconf', 'juniper!', 'candidate')
+    LOG_FORMAT = '%(asctime)s %(levelname)s %(filename)s:%(lineno)d %(message)s'
+    logging.basicConfig(stream=sys.stdout, level=logging.INFO, format=LOG_FORMAT)
+
+    connect('router', 830, 'netconf', 'juniper!')

--- a/examples/juniper/get_l2vpns.py
+++ b/examples/juniper/get_l2vpns.py
@@ -1,17 +1,17 @@
 #!/usr/bin/env python
+import logging
 
 from ncclient import manager
 from ncclient.xml_ import *
-from getpass import getpass
 
 
-def connect(host, user, password):
+def connect(host, port, user, password):
     with manager.connect(
         host=host,
-        port=22,
+        port=port,
         username=user,
         password=password,
-        timeout=10,
+        timeout=60,
         device_params={'name': 'junos'},
         hostkey_verify=False
     ) as conn:
@@ -45,8 +45,10 @@ def connect(host, user, password):
 
     return connection_dict
 
+
 if __name__ == '__main__':
-    host = 'router.example.com'
-    username = raw_input('Give the username for %s: ' % host)
-    password = getpass.getpass('Give the password: ')
-    response = connect(host, username, p)
+    LOG_FORMAT = '%(asctime)s %(levelname)s %(filename)s:%(lineno)d %(message)s'
+    logging.basicConfig(stream=sys.stdout, level=logging.INFO, format=LOG_FORMAT)
+
+    response = connect('router', 22, 'netconf', 'juniper!')
+    logging.info("Response: %s", response)

--- a/examples/juniper/pubkey-auth.py
+++ b/examples/juniper/pubkey-auth.py
@@ -1,18 +1,24 @@
 #!/usr/bin/env python
+import logging
+import sys
 
 from ncclient import manager
 
+
 def connect(host, port, user):
     conn = manager.connect(host=host,
-            port=port,
-            username=user,
-            timeout=10,
-            device_params = {'name':'junos'},
-            hostkey_verify=False)
-
+                           port=port,
+                           username=user,
+                           timeout=60,
+                           device_params={'name': 'junos'},
+                           hostkey_verify=False)
 
     result = conn.get_software_information('brief', test='me')
-    print 'Hostname:', result.xpath('software-information/host-name')[0].text
+    logging.info('Hostname: %s', result.xpath('software-information/host-name')[0].text)
+
 
 if __name__ == '__main__':
+    LOG_FORMAT = '%(asctime)s %(levelname)s %(filename)s:%(lineno)d %(message)s'
+    logging.basicConfig(stream=sys.stdout, level=logging.INFO, format=LOG_FORMAT)
+
     connect('router', 22, 'earies')

--- a/examples/juniper/request-reboot.py
+++ b/examples/juniper/request-reboot.py
@@ -1,24 +1,31 @@
 #!/usr/bin/env python
+import logging
+import sys
+import time
 
 from ncclient import manager
 
-import time
 
 def connect(host, port, user, password):
     conn = manager.connect(host=host,
-            port=port,
-            username=user,
-            password=password,
-            timeout=10,
-            device_params = {'name':'junos'},
-            hostkey_verify=False)
+                           port=port,
+                           username=user,
+                           password=password,
+                           timeout=60,
+                           device_params={'name': 'junos'},
+                           hostkey_verify=False)
 
     result = conn.reboot()
+    logging.info(result)
     reboot_nodes = result.xpath('request-reboot-results/request-reboot-status')
     if reboot_nodes:
         reboot_time = result.xpath('request-reboot-results/request-reboot-status/@reboot-time')[0]
         if 'Shutdown NOW' in reboot_nodes[0].text:
-            print 'Rebooted at:', time.ctime(int(reboot_time))
+            logging.info('Rebooted at: %s', time.ctime(int(reboot_time)))
+
 
 if __name__ == '__main__':
+    LOG_FORMAT = '%(asctime)s %(levelname)s %(filename)s:%(lineno)d %(message)s'
+    logging.basicConfig(stream=sys.stdout, level=logging.INFO, format=LOG_FORMAT)
+
     connect('router', 830, 'netconf', 'juniper!')

--- a/examples/juniper/rollback.py
+++ b/examples/juniper/rollback.py
@@ -1,19 +1,25 @@
 #!/usr/bin/env python
+import logging
+import sys
 
 from ncclient import manager
 
 
 def connect(host, port, user, password):
     conn = manager.connect(host=host,
-            port=port,
-            username=user,
-            password=password,
-            timeout=10,
-            device_params = {'name':'junos'},
-            hostkey_verify=False)
+                           port=port,
+                           username=user,
+                           password=password,
+                           timeout=60,
+                           device_params={'name': 'junos'},
+                           hostkey_verify=False)
 
     rollback_config = conn.rollback(rollback=1)
-    print rollback_config.tostring
+    logging.info(rollback_config)
+
 
 if __name__ == '__main__':
+    LOG_FORMAT = '%(asctime)s %(levelname)s %(filename)s:%(lineno)d %(message)s'
+    logging.basicConfig(stream=sys.stdout, level=logging.INFO, format=LOG_FORMAT)
+
     connect('router', 830, 'netconf', 'juniper!')

--- a/examples/juniper/set-description.py
+++ b/examples/juniper/set-description.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
+import logging
+import sys
+
 from ncclient import manager
-import getpass
 
 
 def connect(host, port, user, password, command):
@@ -9,19 +11,20 @@ def connect(host, port, user, password, command):
         port=port,
         username=user,
         password=password,
-        timeout=10,
+        timeout=60,
         device_params={'name': 'junos'},
         hostkey_verify=False
     ) as m:
-        with m.locked():
-            m.load_configuration(action='set', config=command)
+        with m.locked('candidate'):
+            result = m.load_configuration(action='set', config=command)
+            logging.info(result)
             result = m.commit()
-            print result
+            logging.info(result)
 
 
 if __name__ == '__main__':
-    host = 'router.example.com'
-    username = raw_input('Give the username for %s: ' % host)
-    password = getpass.getpass('Give the password: ')
+    LOG_FORMAT = '%(asctime)s %(levelname)s %(filename)s:%(lineno)d %(message)s'
+    logging.basicConfig(stream=sys.stdout, level=logging.INFO, format=LOG_FORMAT)
+
     interface = 'em0'
-    connect(host, 830, username, password, 'set interfaces %s description example' % interface)
+    connect('router', 830, 'netconf', 'juniper!', 'set interfaces %s description example' % interface)

--- a/examples/juniper/unknown-rpc.py
+++ b/examples/juniper/unknown-rpc.py
@@ -1,23 +1,28 @@
 #!/usr/bin/env python
+import logging
 
 from ncclient import manager
 from ncclient.xml_ import *
 
-def connect(host, port, user, password, source):
-    conn = manager.connect(host=host,
-            port=port,
-            username=user,
-            password=password,
-            timeout=10,
-            device_params = {'name':'junos'},
-            hostkey_verify=False)
 
+def connect(host, port, user, password):
+    conn = manager.connect(host=host,
+                           port=port,
+                           username=user,
+                           password=password,
+                           timeout=60,
+                           device_params={'name': 'junos'},
+                           hostkey_verify=False)
 
     result = conn.get_software_information('brief', test='me')
-    print result.tostring
+    logging.info(result)
 
     result = conn.get_chassis_inventory('extensive')
-    print result.tostring
+    logging.info(result)
+
 
 if __name__ == '__main__':
-    connect('router', 830, 'netconf', 'juniper!', 'candidate')
+    LOG_FORMAT = '%(asctime)s %(levelname)s %(filename)s:%(lineno)d %(message)s'
+    logging.basicConfig(stream=sys.stdout, level=logging.INFO, format=LOG_FORMAT)
+
+    connect('router', 830, 'netconf', 'juniper!')


### PR DESCRIPTION
- Old, python 2 style print statements replaced with logging.info() (logging configured to show date, python file name and line number),
- Using bigger timeout values for manager.connect(), needed by e.g. Juniper SRX 300 (which I could test with) for some operations,
- More meaningful, less confusing/misleading/sloppy variable names,
- get-configuration-jnpr.py: fix: the result of get_configuration() used a bit different data structure,
- get-xnm-information.py: XML (NCElement) to str conversion fix for python 3,
- Some/most PEP 8 code formatting issues were fixed (what I noticed in PyCharm),
- Unnecessary user input (raw_input()) removed from the examples where it was present, easier to run them this way (especially multiple times),
- Note: some examples may still be broken, did not have time to debug all of them.