### PR TITLE
Add support for custom device handlers

### DIFF
--- a/ncclient/manager.py
+++ b/ncclient/manager.py
@@ -71,6 +71,10 @@ def make_device_handler(device_params):
     if device_params is None:
         device_params = {}
 
+    handler = device_params.get('handler', None)
+    if handler:
+        return handler(device_params)
+
     device_name = device_params.get("name", "default")
     # Attempt to import device handler class. All device handlers are
     # in a module called "ncclient.devices.<devicename>" and in a class named
@@ -98,6 +102,9 @@ def connect_ssh(*args, **kwds):
     To invoke advanced vendor related operation add device_params =
         {'name':'<vendor_alias>'} in connection paramerers. For the time,
         'junos' and 'nexus' are supported for Juniper and Cisco Nexus respectively.
+
+    A custom device handler can be provided with device_params =
+        {'handler':<handler class>} in connection paramerers.
     """
     # Extract device parameter dict, if it was passed into this function. Need to
     # remove it from kwds, since the session.connect() doesn't like extra stuff in

--- a/test/unit/test_manager.py
+++ b/test/unit/test_manager.py
@@ -1,6 +1,7 @@
 import unittest
 from mock import patch, MagicMock
 from ncclient import manager
+from ncclient.devices.junos import JunosDeviceHandler
 
 
 class TestManager(unittest.TestCase):
@@ -62,6 +63,13 @@ class TestManager(unittest.TestCase):
 
     def test_make_device_handler(self):
         device_handler = manager.make_device_handler({'name': 'junos'})
+        self.assertEqual(
+            device_handler.__class__.__name__,
+            "JunosDeviceHandler")
+
+    def test_make_device_handler_provided_handler(self):
+        device_handler = manager.make_device_handler(
+            {'handler': JunosDeviceHandler})
         self.assertEqual(
             device_handler.__class__.__name__,
             "JunosDeviceHandler")


### PR DESCRIPTION
Allow a custom device handler to be supplied to the manager via the
device_params dictionary.