### PR TITLE
Merge preparing for 0.5.4 release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,10 @@ if sys.version_info.major == 2 and sys.version_info.minor < 7:
     print ("Sorry, Python < 2.7 is not supported")
     exit()
 
+if sys.version_info.major == 3 and sys.version_info.minor == 7:
+    print ("Sorry, Python 3.7 is not currently supported")
+    exit()
+
 #parse requirements
 req_lines = [line.strip() for line in open("requirements.txt").readlines()]
 install_reqs = list(filter(None, req_lines))
@@ -34,7 +38,7 @@ with codecs.open('README.rst', 'r', encoding='utf8') as file:
 
 
 setup(name='ncclient',
-      version='0.5.3',
+      version='0.5.4',
       description="Python library for NETCONF clients",
       long_description = long_description,
       author="Shikhar Bhushan, Leonidas Poulopoulos, Ebben Aries",
@@ -45,7 +49,7 @@ setup(name='ncclient',
       license="Apache License 2.0",
       platforms=["Posix; OS X; Windows"],
       keywords=('NETCONF', 'NETCONF Python client', 'Juniper Optimization', 'Cisco NXOS Optimization'),
-      python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
+      python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.7.*',
       classifiers=[
           'Development Status :: 5 - Production/Stable',
           'Programming Language :: Python :: 2.7',


### PR DESCRIPTION
Put in checks to disable installation with Python 3.7 due to current use of `async` for parameters, as `async` has been added as a keyword to Python 3.7.