### PR TITLE
Updates to re-enable Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
 - '2.7'
 - '3.4'
 - '3.6'
+- '3.7'
 install:
 - pip install .
 - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python:
 - '2.7'
 - '3.4'
 - '3.6'
-- '3.7'
+- '3.7-dev'
 install:
 - pip install .
 - pip install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -2,22 +2,29 @@
 [![Coverage Status](https://coveralls.io/repos/github/ncclient/ncclient/badge.svg?branch=master)](https://coveralls.io/github/ncclient/ncclient?branch=master)
 [![Documentation Status](https://readthedocs.org/projects/ncclient/badge/?version=latest)](https://readthedocs.org/projects/ncclient/?badge=latest)
 
-ncclient: Python library for NETCONF clients
+# ncclient: Python library for NETCONF clients
 --------------------------------------------
 
 
 ncclient is a Python library that facilitates client-side scripting
 and application development around the NETCONF protocol. `ncclient` was
 developed by [Shikar Bhushan](http://schmizz.net). It is now maintained
-by [Leonidas Poulopoulos (@leopoul)](http://ncclient.org)
+by [Leonidas Poulopoulos (@leopoul)](http://ncclient.org) and Einar Nilsen-Nygaard (@einarnn)
 
 **Docs**: [http://ncclient.readthedocs.org](http://ncclient.readthedocs.org)
 
 **PyPI**: [https://pypi.python.org/pypi/ncclient](https://pypi.python.org/pypi/ncclient)
 
-#### Requirements:
-* Python 2.7 or Python 3.4 to 3.6
-    * Python 3.7 excluded due to use of `async` keyword for versions `0.5.4` and earlier
+## Recent Highlights
+
+|  Date  | Release | Description |
+| :----: | :-----: | :---------- |
+| 07/02/18 | `0.6.0` | Minor release reinstating Python 3.7 and greater compatibility, but necessitating a change to client code that uses `async_mode`. |
+| 07/02/18 | `0.5.4` | New release rolling up myriad of small commits since `0.5.3`. Please note that this release is **incompatible wth Python 3.7** due to the use of a new Python 3.7 keyword, `async`, in function signatures. This will be resolved in 0.6.0|
+
+## Requirements
+
+* Python 2.7 or Python 3.4+
 * setuptools 0.6+
 * Paramiko 1.7+
 * lxml 3.3.0+
@@ -28,7 +35,7 @@ If you are on Debian/Ubuntu install the following libs (via aptitude or apt-get)
 * libxml2-dev
 * libxslt1-dev
 
-#### Installation:
+## Installation
 
     [ncclient] $ sudo python setup.py install
     
@@ -36,12 +43,13 @@ or via pip:
 
     pip install ncclient
 
-#### Examples:
+## Examples:
 
     [ncclient] $ python examples/juniper/*.py
 
-### Usage
-#### Get device running config
+## Usage
+
+### Get device running config
 Use either an interactive Python console (ipython)
 or integrate the following in your code:
 
@@ -66,7 +74,7 @@ For example to invoke Juniper's functions annd params one has to re-write the ab
 
 Device handlers are easy to implement and prove to be futureproof.
 
-#### Supported device handlers
+## Supported device handlers
 
 * Juniper: device_params={'name':'junos'}
 * Cisco CSR: device_params={'name':'csr'}
@@ -80,14 +88,15 @@ Device handlers are easy to implement and prove to be futureproof.
 * Server or anything not in above: device_params={'name':'default'}
 
 
-### Changes | brief - v0.5.3
+## Changes | brief - v0.5.3
 
 * Add notifications support
 * Add support for ecdsa keys
 * Various bug fixes
 
-### Contributors
+## Contributors
 
+* v0.6.0: @einarnn
 * v0.5.4: @adamcubel, Joel Teichroeb, @leopoul, Chase Garner, @budhadityabanerjee, @earies, @ganeshrn, @vnitinv, Siming Yuan, @mirceaaulinic, @stacywsmith, Xavier Hardy, @jwwilcox, @QijunPan, @avangel, @marekgr, @hugovk, @felixonmars, @dexteradeus
 * v0.5.3: [Justin Wilcox](https://github.com/jwwilcox), [Stacy W. Smith](https://github.com/stacywsmith), [Mircea Ulinic](https://github.com/mirceaulinic), [Ebben Aries](https://github.com/earies), [Einar Nilsen-Nygaard](https://github.com/einarnn), [QijunPan](https://github.com/QijunPan)
 * v0.5.2: [Nitin Kumar](https://github.com/vnitinv), [Kristian Larsson](https://github.com/plajjan), [palashgupta](https://github.com/palashgupta), [Jonathan Provost](https://github.com/JoProvost), [Jainpriyal](https://github.com/Jainpriyal), [sharang](https://github.com/sharang), [pseguel](https://github.com/pseguel), [nnakamot](https://github.com/nnakamot), [Алексей Пастухов](https://github.com/p-alik), [Christian Giese](https://github.com/GIC-de), [Peipei Guo](https://github.com/peipeiguo), [Time Warner Cable Openstack Team](https://github.com/twc-openstack)

--- a/README.rst
+++ b/README.rst
@@ -97,6 +97,16 @@ Supported device handlers
 Changes \| brief
 ~~~~~~~~~~~~~~~~
 
+**v0.6.0**
+
+- Fix use of new Python 3.7 keyword, async
+- Re-enable Python 3.7
+
+**v0.5.4**
+
+- Rollup of minor changes since 0.5.3
+- Disablement of Python 3.7 due to async keyword issue
+
 **v0.5.3**
 
 - Add notifications support
@@ -171,6 +181,8 @@ Changes \| brief
 Acknowledgements
 ~~~~~~~~~~~~~~~~
 
+-  v0.6.0: `Einar Nilsen-Nygaard`_
+-  v0.5.4: Various
 -  v0.5.3: `Justin Wilcox`_, `Stacy W. Smith`_, `Mircea Ulinic`_,
    `Ebben Aries`_, `Einar Nilsen-Nygaard`_, `QijunPan`_
 -  v0.5.2: `Nitin Kumar`_, `Kristian Larsson`_, `palashgupta`_,

--- a/ncclient/manager.py
+++ b/ncclient/manager.py
@@ -235,7 +235,7 @@ class Manager(six.with_metaclass(OpExecutor, object)):
     def execute(self, cls, *args, **kwds):
         return cls(self._session,
                    device_handler=self._device_handler,
-                   async=self._async_mode,
+                   async_mode=self._async_mode,
                    timeout=self._timeout,
                    raise_mode=self._raise_mode).request(*args, **kwds)
 

--- a/ncclient/operations/rpc.py
+++ b/ncclient/operations/rpc.py
@@ -263,7 +263,7 @@ class RPC(object):
     "By default :class:`RPCReply`. Subclasses can specify a :class:`RPCReply` subclass."
 
 
-    def __init__(self, session, device_handler, async=False, timeout=30, raise_mode=RaiseMode.NONE):
+    def __init__(self, session, device_handler, async_mode=False, timeout=30, raise_mode=RaiseMode.NONE):
         """
         *session* is the :class:`~ncclient.transport.Session` instance
 
@@ -281,7 +281,7 @@ class RPC(object):
                 self._assert(cap)
         except AttributeError:
             pass
-        self._async = async
+        self._async = async_mode
         self._timeout = timeout
         self._raise_mode = raise_mode
         self._id = uuid4().urn # Keeps things simple instead of having a class attr with running ID that has to be locked

--- a/ncclient/operations/rpc.py
+++ b/ncclient/operations/rpc.py
@@ -396,9 +396,9 @@ class RPC(object):
         """
         return self._event
 
-    def __set_async(self, async=True):
-        self._async = async
-        if async and not self._session.can_pipeline:
+    def __set_async(self, async_mode=True):
+        self._async = async_mode
+        if async_mode and not self._session.can_pipeline:
             raise UserWarning('Asynchronous mode not supported for this device/session')
 
     def __set_raise_mode(self, mode):

--- a/setup.py
+++ b/setup.py
@@ -25,10 +25,6 @@ if sys.version_info.major == 2 and sys.version_info.minor < 7:
     print ("Sorry, Python < 2.7 is not supported")
     exit()
 
-if sys.version_info.major == 3 and sys.version_info.minor == 7:
-    print ("Sorry, Python 3.7 is not currently supported")
-    exit()
-
 #parse requirements
 req_lines = [line.strip() for line in open("requirements.txt").readlines()]
 install_reqs = list(filter(None, req_lines))
@@ -38,7 +34,7 @@ with codecs.open('README.rst', 'r', encoding='utf8') as file:
 
 
 setup(name='ncclient',
-      version='0.5.4',
+      version='0.6.0',
       description="Python library for NETCONF clients",
       long_description = long_description,
       author="Shikhar Bhushan, Leonidas Poulopoulos, Ebben Aries",
@@ -49,13 +45,14 @@ setup(name='ncclient',
       license="Apache License 2.0",
       platforms=["Posix; OS X; Windows"],
       keywords=('NETCONF', 'NETCONF Python client', 'Juniper Optimization', 'Cisco NXOS Optimization'),
-      python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.7.*',
+      python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*,
       classifiers=[
           'Development Status :: 5 - Production/Stable',
           'Programming Language :: Python :: 2.7',
           'Programming Language :: Python :: 3.4',
           'Programming Language :: Python :: 3.5',
           'Programming Language :: Python :: 3.6',
+          'Programming Language :: Python :: 3.7',
           'Topic :: System :: Networking',
           'Intended Audience :: Developers',
           'Operating System :: OS Independent',

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(name='ncclient',
       license="Apache License 2.0",
       platforms=["Posix; OS X; Windows"],
       keywords=('NETCONF', 'NETCONF Python client', 'Juniper Optimization', 'Cisco NXOS Optimization'),
-      python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*,
+      python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*'
       classifiers=[
           'Development Status :: 5 - Production/Stable',
           'Programming Language :: Python :: 2.7',

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(name='ncclient',
       license="Apache License 2.0",
       platforms=["Posix; OS X; Windows"],
       keywords=('NETCONF', 'NETCONF Python client', 'Juniper Optimization', 'Cisco NXOS Optimization'),
-      python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*'
+      python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
       classifiers=[
           'Development Status :: 5 - Production/Stable',
           'Programming Language :: Python :: 2.7',

--- a/test/unit/operations/test_rpc.py
+++ b/test/unit/operations/test_rpc.py
@@ -128,7 +128,7 @@ class TestRPC(unittest.TestCase):
             device_handler,
             raise_mode=RaiseMode.ALL,
             timeout=0,
-            async=True)
+            async_mode=True)
         reply = RPCReply(xml1)
         obj._reply = reply
         node = new_ele("commit")


### PR DESCRIPTION
Requires changing `async` to non-keyword value. Chose to use `async_mode`.