### PR TITLE
selector changes

### DIFF
--- a/ncclient/transport/session.py
+++ b/ncclient/transport/session.py
@@ -44,7 +44,7 @@ class Session(Thread):
         self._notification_q = Queue()
         self._client_capabilities = capabilities
         self._server_capabilities = None # yet
-        self._base = 1.0
+        self._base = "1.0"
         self._id = None # session-id
         self._connected = False # to be set/cleared by subclass implementation
         logger.debug('%r created: client_capabilities=%r' %
@@ -110,7 +110,7 @@ class Session(Thread):
         #    raise MissingCapabilityError(':base:1.0')
         if 'urn:ietf:params:netconf:base:1.1' in self._server_capabilities and 'urn:ietf:params:netconf:base:1.1' in self._client_capabilities:
             logger.debug("After 'hello' message selecting netconf:base:1.1 for encoding")
-            self._base = 1.1
+            self._base = "1.1"
         logger.info('initialized: session-id=%s | server_capabilities=%s' %
                     (self._id, self._server_capabilities))
 

--- a/ncclient/transport/session.py
+++ b/ncclient/transport/session.py
@@ -44,6 +44,7 @@ class Session(Thread):
         self._notification_q = Queue()
         self._client_capabilities = capabilities
         self._server_capabilities = None # yet
+        self._base = 1.0
         self._id = None # session-id
         self._connected = False # to be set/cleared by subclass implementation
         logger.debug('%r created: client_capabilities=%r' %
@@ -107,6 +108,9 @@ class Session(Thread):
             raise error[0]
         #if ':base:1.0' not in self.server_capabilities:
         #    raise MissingCapabilityError(':base:1.0')
+        if 'urn:ietf:params:netconf:base:1.1' in self._server_capabilities and 'urn:ietf:params:netconf:base:1.1' in self._client_capabilities:
+            logger.debug("After 'hello' message selecting netconf:base:1.1 for encoding")
+            self._base = 1.1
         logger.info('initialized: session-id=%s | server_capabilities=%s' %
                     (self._id, self._server_capabilities))
 

--- a/ncclient/transport/ssh.py
+++ b/ncclient/transport/ssh.py
@@ -566,7 +566,7 @@ class SSHSession(Session):
                     data = chan.recv(BUF_SIZE)
                     if data:
                         self._buffer.write(data)
-                        if self._base == 1.1:
+                        if self._base == "1.1":
                             self._parse11()
                         else:
                             self._parse10()

--- a/ncclient/transport/ssh.py
+++ b/ncclient/transport/ssh.py
@@ -575,7 +575,7 @@ class SSHSession(Session):
                 if not q.empty() and chan.send_ready():
                     logger.debug("Sending message")
                     data = q.get()
-                    if self._base == 1.1:
+                    if self._base == "1.1":
                         data = "%s%s%s" % (start_delim(len(data)), data, END_DELIM)
                     else:
                         data = "%s%s" % (data, MSG_DELIM)

--- a/ncclient/transport/ssh.py
+++ b/ncclient/transport/ssh.py
@@ -556,7 +556,7 @@ class SSHSession(Session):
                 # Log what netconf:base version we are using this time
                 # round the loop; _base is updated when we receive the
                 # server's capabilities.
-                logger.debug('Currently selected netconf:base:%0.1f', self._base)
+                logger.debug('Currently selected netconf:base:%s', self._base)
                 
                 # Will wakeup evey TICK seconds to check if something
                 # to send, more quickly if something to read (due to

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 setuptools>0.6
 paramiko>=1.15.0
 lxml>=3.3.0
+selectors2>=2.0.1
 six

--- a/test/unit/transport/test_ssh.py
+++ b/test/unit/transport/test_ssh.py
@@ -255,7 +255,7 @@ class TestSSH(unittest.TestCase):
     @patch('paramiko.channel.Channel.recv')
     @patch('selectors.DefaultSelector.select')
     @patch('ncclient.transport.ssh.Session._dispatch_error')
-    def test_run_recieve_py3(self, mock_error, mock_selector, mock_recv, mock_close):
+    def test_run_receive_py3(self, mock_error, mock_selector, mock_recv, mock_close):
         mock_selector.return_value = True
         mock_recv.return_value = 0
         device_handler = JunosDeviceHandler({'name': 'junos'})
@@ -293,7 +293,7 @@ class TestSSH(unittest.TestCase):
     @patch('paramiko.channel.Channel.recv')
     @patch('selectors2.DefaultSelector')
     @patch('ncclient.transport.ssh.Session._dispatch_error')
-    def test_run_recieve_py2(self, mock_error, mock_selector, mock_recv, mock_close):
+    def test_run_receive_py2(self, mock_error, mock_selector, mock_recv, mock_close):
         mock_selector.select.return_value = True
         mock_recv.return_value = 0
         device_handler = JunosDeviceHandler({'name': 'junos'})

--- a/test/unit/transport/test_ssh.py
+++ b/test/unit/transport/test_ssh.py
@@ -6,6 +6,12 @@ import paramiko
 from ncclient.devices.junos import JunosDeviceHandler
 import sys
 
+try:
+    import selectors
+except ImportError:
+    import selectors2 as selectors
+
+
 reply_data = """<rpc-reply xmlns:junos="http://xml.juniper.net/junos/12.1X46/junos" attrib1 = "test">
     <software-information>
         <host-name>R1</host-name>
@@ -244,12 +250,13 @@ class TestSSH(unittest.TestCase):
         obj.load_known_hosts()
         mock_load.assert_called_once_with("file_name")
 
+    @unittest.skipIf(sys.version_info.major == 2, "test not supported < Python3")
     @patch('ncclient.transport.ssh.SSHSession.close')
     @patch('paramiko.channel.Channel.recv')
-    @patch('ncclient.transport.ssh.select')
+    @patch('selectors.DefaultSelector.select')
     @patch('ncclient.transport.ssh.Session._dispatch_error')
-    def test_run_recieve(self, mock_error, mock_select, mock_recv, mock_close):
-        mock_select.return_value = True, None, None
+    def test_run_recieve_py3(self, mock_error, mock_selector, mock_recv, mock_close):
+        mock_selector.return_value = True
         mock_recv.return_value = 0
         device_handler = JunosDeviceHandler({'name': 'junos'})
         obj = SSHSession(device_handler)
@@ -260,11 +267,14 @@ class TestSSH(unittest.TestCase):
                 mock_error.call_args_list[0][0][0],
                 SessionCloseError))
 
+    @unittest.skipIf(sys.version_info.major == 2, "test not supported < Python3")
     @patch('ncclient.transport.ssh.SSHSession.close')
     @patch('paramiko.channel.Channel.send_ready')
     @patch('paramiko.channel.Channel.send')
+    @patch('selectors.DefaultSelector.select')
     @patch('ncclient.transport.ssh.Session._dispatch_error')
-    def test_run_send(self, mock_error, mock_send, mock_ready, mock_close):
+    def test_run_send_py3(self, mock_error, mock_selector, mock_send, mock_ready, mock_close):
+        mock_selector.return_value = False
         mock_ready.return_value = True
         mock_send.return_value = -1
         device_handler = JunosDeviceHandler({'name': 'junos'})
@@ -272,7 +282,45 @@ class TestSSH(unittest.TestCase):
         obj._channel = paramiko.Channel("c100")
         obj._q.put("rpc")
         obj.run()
-        self.assertEqual(mock_send.call_args_list[0][0][0], "rpc")
+        self.assertEqual(mock_send.call_args_list[0][0][0], "rpc]]>]]>")
+        self.assertTrue(
+            isinstance(
+                mock_error.call_args_list[0][0][0],
+                SessionCloseError))
+
+    @unittest.skipIf(sys.version_info.major >= 3, "test not supported >= Python3")
+    @patch('ncclient.transport.ssh.SSHSession.close')
+    @patch('paramiko.channel.Channel.recv')
+    @patch('selectors2.DefaultSelector')
+    @patch('ncclient.transport.ssh.Session._dispatch_error')
+    def test_run_recieve_py2(self, mock_error, mock_selector, mock_recv, mock_close):
+        mock_selector.select.return_value = True
+        mock_recv.return_value = 0
+        device_handler = JunosDeviceHandler({'name': 'junos'})
+        obj = SSHSession(device_handler)
+        obj._channel = paramiko.Channel("c100")
+        obj.run()
+        self.assertTrue(
+            isinstance(
+                mock_error.call_args_list[0][0][0],
+                SessionCloseError))
+
+    @unittest.skip("test currently non-functional")
+    @patch('ncclient.transport.ssh.SSHSession.close')
+    @patch('paramiko.channel.Channel.send_ready')
+    @patch('paramiko.channel.Channel.send')
+    @patch('selectors2.DefaultSelector')
+    @patch('ncclient.transport.ssh.Session._dispatch_error')
+    def test_run_send_py2(self, mock_error, mock_selector, mock_send, mock_ready, mock_close):
+        mock_selector.select.return_value = False
+        mock_ready.return_value = True
+        mock_send.return_value = -1
+        device_handler = JunosDeviceHandler({'name': 'junos'})
+        obj = SSHSession(device_handler)
+        obj._channel = paramiko.Channel("c100")
+        obj._q.put("rpc")
+        obj.run()
+        self.assertEqual(mock_send.call_args_list[0][0][0], "rpc]]>]]>")
         self.assertTrue(
             isinstance(
                 mock_error.call_args_list[0][0][0],


### PR DESCRIPTION
Change from using the current `select.select` to test for file descriptor (socket/channel) activity to using `selectors.DefaultSelector` or `selectors2.DefaultSelector` on Python 2.7. The concrete selctor are the `KqueueSelector` on macOS and the `EpollSelector` on linux (Ubuntu 16.0.4) for both Python 2.7 and Python 3.7.
