### PR TITLE
check for transform_reply type

### DIFF
--- a/ncclient/xml_.py
+++ b/ncclient/xml_.py
@@ -19,6 +19,7 @@
 import io
 import sys
 import six
+import types
 from six import StringIO
 from io import BytesIO
 from lxml import etree
@@ -148,12 +149,15 @@ XPATH_NAMESPACES = {
     're':'http://exslt.org/regular-expressions'
 }
 
+
 class NCElement(object):
     def __init__(self, result, transform_reply):
         self.__result = result
         self.__transform_reply = transform_reply
-        self.__doc = self.remove_namespaces(self.__result)
-
+        if isinstance(transform_reply, types.FunctionType):
+            self.__doc = self.__transform_reply(result._root)
+        else:
+            self.__doc = self.remove_namespaces(self.__result)
 
     def xpath(self, expression):
         """


### PR DESCRIPTION
a user can pass transform reply as function. So with this, users' can use their own logic to transform the xml. 
With this functionality, I am not bound to use xslt for transformation. For a 24000 IFL configuration (100mb data) took 45 sec to parse. With our own remove_namespace logic it takes 8 seconds only. We also see these benefits 


  | Old Code | New Code | Improvement
-- | -- | -- | --
CPU | 1.8GB | 850 MB | > 50%
Time Taken | 140 sec | 95 sec | > 30%


Example of how to use this feature
https://github.com/vnitinv/py-junos-eznc/commit/43f79262a84f01c9acbaf407d3a7f4c2a6a631c1
