### PR TITLE
Fix in get_schema for junos

### DIFF
--- a/ncclient/operations/retrieve.py
+++ b/ncclient/operations/retrieve.py
@@ -73,8 +73,8 @@ class GetSchemaReply(GetReply):
     def _parsing_hook(self, root):
         self._data = None
         if not self._errors:
-            self._data = root.find(qualify("data", NETCONF_MONITORING_NS)).text
-
+            data = root.find(qualify("data", NETCONF_MONITORING_NS))
+            self._data = data.text if data else None
 
 class Get(RPC):
 


### PR DESCRIPTION
Fixes #276

* Get text of root node only when the node is found
  else return None

Before Fix:
```
Error: 'NoneType' object has no attribute 'text'
```

After fix:
Received correct [xml response](https://gist.github.com/ganeshrn/02d20623cd17f6cfac61f3210066cde5)