### PR TITLE
Clixon device definition

### DIFF
--- a/ncclient/devices/clixon.py
+++ b/ncclient/devices/clixon.py
@@ -1,0 +1,31 @@
+"""
+Handler for Clixon based device specific information.
+
+Note that for proper import, the classname has to be:
+
+    "<Devicename>DeviceHandler"
+
+...where <Devicename> is something like "Default", "Nexus", etc.
+
+All device-specific handlers derive from the DefaultDeviceHandler, which implements the
+generic information needed for interaction with a Netconf server.
+
+"""
+
+
+from .default import DefaultDeviceHandler
+
+def iosxr_unknown_host_cb(host, fingerprint):
+        #This will ignore the unknown host check when connecting to Clixon based devices
+        return True
+
+class ClixonDeviceHandler(DefaultDeviceHandler):
+    """
+    Clixon handler for device specific information.
+
+    """
+    def __init__(self, device_params):
+        super(ClixonDeviceHandler, self).__init__(device_params)
+
+    def perform_qualify_check(self):
+        return False


### PR DESCRIPTION
Clixon (https://github.com/clicon/clixon) automatically generates CLI, Netconf and Restconf from YANG specification. I had a problem using ncclient to connect to a Clixon-generated Netconf service, and it turned out to be similar to issue #108. Following the advice given in that thread, I created a device profile for Clixon. It is contained in this PR.

Kind regards
Jan