### PR TITLE
Removed parser call to to_ele

### DIFF
--- a/ncclient/devices/junos.py
+++ b/ncclient/devices/junos.py
@@ -68,7 +68,7 @@ class JunosDeviceHandler(DefaultDeviceHandler):
                     xslt = etree.XSLT(etree.XML(add_ns))
                     transformed_xml = etree.XML(etree.tostring(xslt(doc)))
                     err_list.append(RPCError(transformed_xml))
-                return RPCError(to_ele(''.join(errs)), err_list)
+                return RPCError(''.join(errs), err_list)
         else:
             return False
 


### PR DESCRIPTION
Helps to resolve PyEZ ConnectError for `Unauthorised user`.

Tracked in PyEZ via https://github.com/Juniper/py-junos-eznc/issues/874