### PR TITLE
Updated junos.py to resolve RestrictedUser warnings

### DIFF
--- a/ncclient/devices/junos.py
+++ b/ncclient/devices/junos.py
@@ -68,7 +68,7 @@ class JunosDeviceHandler(DefaultDeviceHandler):
                     xslt = etree.XSLT(etree.XML(add_ns))
                     transformed_xml = etree.XML(etree.tostring(xslt(doc)))
                     err_list.append(RPCError(transformed_xml))
-                return RPCError(to_ele(''.join(errs)), err_list)
+                return RPCError(to_ele(''.join(errs))to_ele("<rpc-reply>"+''.join(errs)+"</rpc-reply>"), err_list)
         else:
             return False
 


### PR DESCRIPTION
- Currently, we get multiple RPC replies causing the call to_ele to fail. So, the change squashes all rpc-errors into a single rpc-reply element
- The issue is internally tracked in Pyez via: https://github.com/Juniper/py-junos-eznc/issues/874