### PR TITLE
Close the channel when closing SSH session

### DIFF
--- a/ncclient/transport/ssh.py
+++ b/ncclient/transport/ssh.py
@@ -285,6 +285,8 @@ class SSHSession(Session):
         while self.is_alive() and (self is not threading.current_thread()):
             self.join(10)
 
+        if self._channel:
+            self._channel.close()
         self._channel = None
         self._connected = False
 


### PR DESCRIPTION
I had an error when opening and closing SSH sessions to several hundreds of devices because of too many file descriptors opened.

Close all file descriptors that have been opened by the channel, fixing the issue.