### PR TITLE
Pin selectors2 to Python versions <= 3.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 setuptools>0.6
 paramiko>=1.15.0
 lxml>=3.3.0
-selectors2>=2.0.1
+selectors2>=2.0.1; python_version <= '3.4'
 six


### PR DESCRIPTION
Pin the "selectors2" package to Python versions lower/equal than 3.4 . Otherwise packages, that depends on ncclient, e.g. napalm will fail at runtime when used with Python 3.6 or later.

This should fix #291 