### PR TITLE
Fix config examples to actually use the `nc` namespace.

### DIFF
--- a/examples/nc04.py
+++ b/examples/nc04.py
@@ -10,12 +10,12 @@ warnings.simplefilter("ignore", DeprecationWarning)
 from ncclient import manager
 
 def demo(host, user, name, uid, gid):
-    snippet = """<config xmlns:xc="urn:ietf:params:xml:ns:netconf:base:1.0">
+    snippet = """<nc:config xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
       <aaa xmlns="http://tail-f.com/ns/aaa/1.1">
-        <authentication> <users> <user xc:operation="create">
+        <authentication> <users> <user nc:operation="create">
         <name>%s</name> <uid>%s</uid> <gid>%s</gid>
         <password>*</password> <ssh_keydir/> <homedir/>
-      </user></users></authentication></aaa></config>""" % (name, uid, gid)
+      </user></users></authentication></aaa></nc:config>""" % (name, uid, gid)
 
     with manager.connect(host=host, port=22, username=user) as m:
         assert(":validate" in m.server_capabilities)

--- a/examples/nc05.py
+++ b/examples/nc05.py
@@ -11,11 +11,11 @@ warnings.simplefilter("ignore", DeprecationWarning)
 from ncclient import manager
 
 def demo(host, user, name):
-    snippet = """<config xmlns:xc="urn:ietf:params:xml:ns:netconf:base:1.0">
+    snippet = """<nc:config xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
       <aaa xmlns="http://tail-f.com/ns/aaa/1.1">
-        <authentication> <users> <user xc:operation="delete">
+        <authentication> <users> <user nc:operation="delete">
         <name>%s</name>
-      </user></users></authentication></aaa></config>""" % name
+      </user></users></authentication></aaa></nc:config>""" % name
 
     with manager.connect(host=host, port=22, username=user) as m:
         assert(":validate" in m.server_capabilities)

--- a/examples/nc06.py
+++ b/examples/nc06.py
@@ -9,10 +9,10 @@ import sys, os, warnings
 warnings.simplefilter("ignore", DeprecationWarning)
 from ncclient import manager
 
-template = """<config xmlns:xc="urn:ietf:params:xml:ns:netconf:base:1.0">
+template = """<nc:config xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
   <aaa xmlns="http://tail-f.com/ns/aaa/1.1">
-  <authentication> <users> <user xc:operation="delete">
-  <name>%s</name> </user></users></authentication></aaa></config>"""
+  <authentication> <users> <user nc:operation="delete">
+  <name>%s</name> </user></users></authentication></aaa></nc:config>"""
 
 def demo(host, user, names):
     with manager.connect(host=host, port=22, username=user) as m:

--- a/examples/nc07.py
+++ b/examples/nc07.py
@@ -9,10 +9,10 @@ import sys, os, warnings
 warnings.simplefilter("ignore", DeprecationWarning)
 from ncclient import manager
 
-template = """<config xmlns:xc="urn:ietf:params:xml:ns:netconf:base:1.0">
+template = """<nc:config xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
   <aaa xmlns="http://tail-f.com/ns/aaa/1.1">
-  <authentication> <users> <user xc:operation="delete">
-  <name>%s</name> </user></users></authentication></aaa></config>"""
+  <authentication> <users> <user nc:operation="delete">
+  <name>%s</name> </user></users></authentication></aaa></nc:config>"""
 
 def demo(host, user, names):
     with manager.connect(host=host, port=22, username=user) as m:

--- a/examples/nxosapi.py
+++ b/examples/nxosapi.py
@@ -13,7 +13,7 @@ warnings.simplefilter("ignore", DeprecationWarning)
 from ncclient import manager
 
 exec_conf_prefix = """
-      <config xmlns:xc="urn:ietf:params:xml:ns:netconf:base:1.0">
+      <nc:config xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
         <configure xmlns="http://www.cisco.com/nxos:1.0:vlan_mgr_cli">
           <__XML__MODE__exec_configure>
 """
@@ -21,7 +21,7 @@ exec_conf_prefix = """
 exec_conf_postfix = """
           </__XML__MODE__exec_configure>
         </configure>
-      </config>
+      </nc:config>
 """
 
 cmd_vlan_conf_snippet= """
@@ -67,7 +67,7 @@ cmd_vlan_int_snippet = """
 """
 
 cmd_no_vlan_int_snippet = """
-      <config xmlns:xc="urn:ietf:params:xml:ns:netconf:base:1.0">
+      <nc:config xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
         <configure xmlns="http://www.cisco.com/nxos:1.0:vlan_mgr_cli">
           <__XML__MODE__exec_configure>
           <interface>
@@ -92,7 +92,7 @@ cmd_no_vlan_int_snippet = """
           </interface>
           </__XML__MODE__exec_configure>
         </configure>
-      </config>
+      </nc:config>
 """
 
 filter_show_vlan_brief_snippet =  """


### PR DESCRIPTION
In the examples, the <config> node wasn't actually using the prefix.
If an XML node uses no XML namespace, it defaults to the ancestor
default. In ncclient, the root <rpc> node has no default namespace, only
`nc` which maps to `urn:ietf:params:xml:ns:netconf:base:1.0`.

Pedantic NETCONF servers were rejecting the RPCs, since the <config>
element was not in the correct namespace.

I also changed the `xc` namespace prefix, to match with one defined in the
ancestor `<rpc>` node.