### PR TITLE
Correctly set port number in in ProxyCommand when using ssh_config file

### DIFF
--- a/test/unit/ssh_config
+++ b/test/unit/ssh_config
@@ -1,0 +1,3 @@
+Host fake_host
+    hostname 10.0.0.1
+    proxycommand ssh -W %h:%p jumphost.domain.com


### PR DESCRIPTION
In order to use a jumphost to communicate with a network device, you need to set the ProxyCommand in your ssh_config file to specify the jumphost to connect to.

For example, if you are trying to connect to 10.0.0.1 via jumphost.domain.com you need the following in your ssh_config
```
Host 10.0.0.1
    hostname 10.0.0.1
    proxycommand ssh -W %h:%p jumphost.domain.com
```
When you attempt to connect to 10.0.0.1 %h and %p are replaced with the target host and the target port number respectively.

When using ncclient and using this strategy the replacement of %p is replaced with the default port in paramiko (22) rather than the port you have specified in manager.connect()

As a result you are connected to port 22 regardless of what port number is passed into manager.connect.

This pull request fixes this so that the correct port is used