### PR TITLE
Juniper RPC: allow specifying format in CompareConfiguration

### DIFF
--- a/ncclient/operations/third_party/juniper/rpc.py
+++ b/ncclient/operations/third_party/juniper/rpc.py
@@ -35,8 +35,8 @@ class LoadConfiguration(RPC):
             return self._request(node)
 
 class CompareConfiguration(RPC):
-    def request(self, rollback=0):
-        node = new_ele('get-configuration', {'compare':'rollback', 'rollback':str(rollback)})
+    def request(self, rollback=0, format='text'):
+        node = new_ele('get-configuration', {'compare':'rollback', 'format':format, 'rollback':str(rollback)})
         return self._request(node)
 
 class ExecuteRpc(RPC):

--- a/test/unit/operations/third_party/juniper/test_rpc.py
+++ b/test/unit/operations/third_party/juniper/test_rpc.py
@@ -147,7 +147,7 @@ class TestRPC(unittest.TestCase):
             raise_mode=RaiseMode.ALL)
         obj.request(rollback=2)
         node = new_ele(
-            'get-configuration', {'compare': 'rollback', 'rollback': str(2)})
+            'get-configuration', {'compare': 'rollback', 'rollback': str(2), 'format': 'text'})
         call = mock_request.call_args_list[0][0][0]
         self.assertEqual(call.tag, node.tag)
         self.assertEqual(call.attrib, node.attrib)


### PR DESCRIPTION
This change allows you to specify the format for comparison between configrations.
Text seems to be the implicit default for any value of rollback other than the default (0) so it is a good choice and will result in uniform output i.e. you can rely on there being a `configuration-output` element if there is a difference.