### PR TITLE
Fix filter in create_subscription in issue#224

### DIFF
--- a/ncclient/operations/util.py
+++ b/ncclient/operations/util.py
@@ -58,7 +58,8 @@ def build_filter(spec, capcheck=None):
             raise OperationError("Invalid filter type")
     else:
 
-        rep = validated_element(spec, ("filter", qualify("filter")))
+        rep = validated_element(spec, ("filter", qualify("filter"),
+                                       qualify("filter", ns=NETCONF_NOTIFICATION_NS)))
         # results in XMLError: line 105 ncclient/xml_.py - commented by earies - 5/10/13
         #rep = validated_element(spec, ("filter", qualify("filter")),
         #                                attrs=("type",))


### PR DESCRIPTION
As per RFC5277 page 29, "filter" in "create-subscription" is in namespace "urn:ietf:params:xml:ns:netconf:notification:1.0". However, in RFC6241 page 27, "filter" in "get-config" is in namespace "urn:ietf:params:xml:ns:netconf:base:1.0".

The issue is create_subscription() returns error with correct filter:
>>> filter = """
... <filter xmlns="urn:ietf:params:xml:ns:netconf:notification:1.0"
...         xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0"
...         nc:type="subtree">
...   <foo xmlns="urn:params:xml:ns:yang:foo">
...   </foo>
... </filter>"""
>>> reply = nc.create_subscription(filter=filter)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/jonyang/Projects/unclean/ncdiff/src/ncdiff/manager.py", line 343, in execute
    reply = super().execute(cls, *args, **kwargs)
  File "/home/jonyang/Projects/env1/lib/python3.6/site-packages/ncclient/manager.py", line 216, in execute
    raise_mode=self._raise_mode).request(*args, **kwds)
  File "/home/jonyang/Projects/env1/lib/python3.6/site-packages/ncclient/operations/subscribe.py", line 52, in request
    node.append(util.build_filter(filter))
  File "/home/jonyang/Projects/env1/lib/python3.6/site-packages/ncclient/operations/util.py", line 61, in build_filter
    rep = validated_element(spec, ("filter", qualify("filter")))
  File "/home/jonyang/Projects/env1/lib/python3.6/site-packages/ncclient/xml_.py", line 137, in validated_element
    raise XMLError("Element [%s] does not meet requirement" % ele.tag)
ncclient.xml_.XMLError: Element [{urn:ietf:params:xml:ns:netconf:notification:1.0}filter] does not meet requirement
>>>

So the fix is extending allowable tags in validated_element().