### PR TITLE
Validate 'with-defaults' mode based on supported modes advertised in capability URI

### DIFF
--- a/ncclient/capabilities.py
+++ b/ncclient/capabilities.py
@@ -97,7 +97,7 @@ class Capability(object):
 
     @classmethod
     def from_uri(cls, uri):
-        split_uri = uri.split('?')
+        split_uri = uri.split("?")
         namespace_uri = split_uri[0]
         capability = cls(namespace_uri)
 
@@ -124,7 +124,7 @@ class Capability(object):
 
 
 def _parse_parameter_string(string, uri):
-    for param_string in string.split('&'):
+    for param_string in string.split("&"):
         try:
             yield _Parameter.from_string(param_string)
         except _InvalidParameter:
@@ -147,7 +147,7 @@ class _Parameter(object):
     @classmethod
     def from_string(cls, string):
         try:
-            key, value = string.split('=')
+            key, value = string.split("=")
         except ValueError:
             raise _InvalidParameter
 

--- a/ncclient/capabilities.py
+++ b/ncclient/capabilities.py
@@ -108,6 +108,12 @@ class Capability(object):
 
         return capability
 
+    def __eq__(self, other):
+        return (
+            self.namespace_uri == other.namespace_uri and
+            self.parameters == other.parameters
+        )
+
     def get_abbreviations(self):
         return _abbreviate(self.namespace_uri)
 

--- a/ncclient/operations/retrieve.py
+++ b/ncclient/operations/retrieve.py
@@ -114,6 +114,7 @@ def _validate_with_defaults_mode(mode, capabilities):
 
 
 def _get_valid_with_defaults_modes(capabilities):
+    """Reference: https://tools.ietf.org/html/rfc6243#section-4.3"""
     capability = capabilities[":with-defaults"]
 
     try:


### PR DESCRIPTION
Summary of changes:
- Represent capabilities as objects with separate namespace URI and parameters
- Provide an interface for accessing individual capabilities in order to check these parameters
- Validate the `with-defaults` mode using the modes advertised by the server via the parameters in the capability URI
