### PR TITLE
Fix docs build

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -19,10 +19,11 @@ import sys, os
 sys.path.insert(0, os.path.abspath("../.."))
 
 # -- General configuration -----------------------------------------------------
+needs_sphinx = '2.0'
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest', 'sphinx.ext.intersphinx', 'sphinx.ext.todo', 'sphinx.ext.coverage', 'sphinx.ext.pngmath', 'sphinx.ext.ifconfig']
+extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest', 'sphinx.ext.intersphinx', 'sphinx.ext.todo', 'sphinx.ext.coverage', 'sphinx.ext.imgmath', 'sphinx.ext.ifconfig']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
This patch fixes a problem with building the documentation with
sphinx. sphinx.ext.pngmath doesn't exist in versions of
sphinx >= 2.0.