### PR TITLE
Add tox support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ venv/
 ENV/
 
 .idea
+
+.coverage
+docs/html
+.tox

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,4 @@ graft docs
 graft examples
 include versioneer.py
 include ncclient/_version.py
+include test

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,9 @@
+[aliases]
+test=pytest
+
+[tool:pytest]
+addopts = --verbose
+
 [metadata]
 description-file = README.md
 
@@ -14,3 +20,4 @@ VCS = git
 style = pep440
 versionfile_source = ncclient/_version.py
 tag_prefix = v
+

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,9 @@ if sys.version_info.major == 2 and sys.version_info.minor < 7:
 req_lines = [line.strip() for line in open("requirements.txt").readlines()]
 install_reqs = list(filter(None, req_lines))
 
+test_req_lines = [line.strip() for line in open("test-requirements.txt").readlines()]
+test_reqs = list(filter(None, test_req_lines))
+
 with codecs.open('README.rst', 'r', encoding='utf8') as file:
     long_description = file.read()
 
@@ -48,9 +51,10 @@ setup(name='ncclient',
       url="https://github.com/ncclient/ncclient",
       packages=find_packages('.'),
       install_requires=install_reqs,
+      tests_require=test_reqs,
       license=__licence__,
       platforms=["Posix; OS X; Windows"],
-      keywords=('NETCONF', 'NETCONF Python client', 'Juniper Optimization', 'Cisco NXOS Optimization'),
+      keywords=['NETCONF', 'NETCONF Python client', 'Juniper Optimization', 'Cisco NXOS Optimization'],
       python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
       classifiers=[
           'Development Status :: 5 - Production/Stable',

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,6 @@
+pytest-runner
+pytest-cov
+sphinx
+flake8
+mock
+nose

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,31 @@
+[tox]
+minversion = 1.6
+skipdist = True
+envlist = py27,py36,py37,pep8,cover,docs
+
+[testenv]
+setenv = VIRTUAL_ENV={envdir}
+usedevelop = True
+install_command = pip install {opts} {packages}
+
+deps = -r{toxinidir}/requirements.txt
+       -r{toxinidir}/test-requirements.txt
+commands =
+  pytest {posargs}
+
+[testenv:cover]
+commands =
+  pytest --cov=ncclient
+
+[testenv:docs]
+deps = -r{toxinidir}/test-requirements.txt
+commands = sphinx-build -b html docs/source docs/html
+
+[testenv:pep8]
+commands =
+  flake8 {posargs} ncclient test
+
+[flake8]
+show-source = True
+ignore = E713
+exclude = .venv,.git,.tox,dist,doc,.ropeproject


### PR DESCRIPTION
This patch adds tox support to the project for running pep8,
documentation building and testing against py27 and py3.

The pep8 tests fail due to various actual pep8 violations, but at least
this patch allows one to run the pep8 tests.