### PR TITLE
Add option to parse XML replies with huge text node (fixes #185)

### DIFF
--- a/docs/source/manager.rst
+++ b/docs/source/manager.rst
@@ -86,6 +86,7 @@ Presence of capabilities is verified to the extent possible, and you can expect 
 
     .. autoattribute:: connected
 
+    .. autoattribute:: huge_tree
 
 Special kinds of parameters
 ---------------------------

--- a/docs/source/manager.rst
+++ b/docs/source/manager.rst
@@ -38,6 +38,8 @@ Presence of capabilities is verified to the extent possible, and you can expect 
 
 .. autoclass:: Manager
 
+    .. autoattribute:: HUGE_TREE_DEFAULT
+
     .. automethod:: get_config(source, filter=None)
 
     .. automethod:: edit_config(target, config, default_operation=None, test_option=None, error_option=None)

--- a/docs/source/operations.rst
+++ b/docs/source/operations.rst
@@ -11,7 +11,7 @@ Base classes
 ------------
 
 .. autoclass:: RPC
-    :members: DEPENDS, REPLY_CLS, _assert, _request, request, event, error, reply, raise_mode, is_async, timeout
+    :members: DEPENDS, REPLY_CLS, _assert, _request, request, event, error, reply, raise_mode, is_async, timeout, huge_tree
 
 .. autoclass:: RPCReply
     :members: xml, ok, error, errors, _parsing_hook

--- a/ncclient/manager.py
+++ b/ncclient/manager.py
@@ -198,12 +198,16 @@ class Manager(object):
 
    # __metaclass__ = OpExecutor
 
+
+    HUGE_TREE_DEFAULT = False
+    """Default for `huge_tree` support for XML parsing of RPC replies (defaults to False)"""
+
     def __init__(self, session, device_handler, timeout=30):
         self._session = session
         self._async_mode = False
         self._timeout = timeout
         self._raise_mode = operations.RaiseMode.ALL
-        self._huge_tree = False
+        self._huge_tree = self.HUGE_TREE_DEFAULT
         self._device_handler = device_handler
 
     def __enter__(self):
@@ -336,7 +340,8 @@ class Manager(object):
 
     @property
     def huge_tree(self):
-        """Whether `huge_tree` support for xml parsing of RPC replies is enabled (default=False)"""
+        """Whether `huge_tree` support for XML parsing of RPC replies is enabled (default=False)
+        The default value is configurable through :attr:`~ncclient.manager.Manager.HUGE_TREE_DEFAULT`"""
         return self._huge_tree
 
     @huge_tree.setter

--- a/ncclient/manager.py
+++ b/ncclient/manager.py
@@ -203,6 +203,7 @@ class Manager(object):
         self._async_mode = False
         self._timeout = timeout
         self._raise_mode = operations.RaiseMode.ALL
+        self._huge_tree = False
         self._device_handler = device_handler
 
     def __enter__(self):
@@ -227,7 +228,8 @@ class Manager(object):
                    device_handler=self._device_handler,
                    async_mode=self._async_mode,
                    timeout=self._timeout,
-                   raise_mode=self._raise_mode).request(*args, **kwds)
+                   raise_mode=self._raise_mode,
+                   huge_tree=self._huge_tree).request(*args, **kwds)
 
     def locked(self, target):
         """Returns a context manager for a lock on a datastore, where
@@ -331,3 +333,12 @@ class Manager(object):
     exceptions. Valid values are the constants defined in
     :class:`~ncclient.operations.RaiseMode`.
     The default value is :attr:`~ncclient.operations.RaiseMode.ALL`."""
+
+    @property
+    def huge_tree(self):
+        """Whether `huge_tree` support for xml parsing of RPC replies is enabled (default=False)"""
+        return self._huge_tree
+
+    @huge_tree.setter
+    def huge_tree(self, x):
+        self._huge_tree = x

--- a/ncclient/operations/rpc.py
+++ b/ncclient/operations/rpc.py
@@ -120,6 +120,10 @@ class RPCReply(object):
 
     """Represents an *rpc-reply*. Only concerns itself with whether the operation was successful.
 
+    *raw*: the raw unparsed reply
+
+    *huge_tree*: parse XML with very deep trees and very long text content
+
     .. note::
         If the reply has not yet been parsed there is an implicit, one-time parsing overhead to
         accessing some of the attributes defined by this class.
@@ -431,6 +435,7 @@ class RPC(object):
 
     @property
     def huge_tree(self):
+        """Whether `huge_tree` support for XML parsing of RPC replies is enabled (default=False)"""
         return self._huge_tree
 
     @huge_tree.setter

--- a/ncclient/operations/rpc.py
+++ b/ncclient/operations/rpc.py
@@ -128,11 +128,12 @@ class RPCReply(object):
     ERROR_CLS = RPCError
     "Subclasses can specify a different error class, but it should be a subclass of `RPCError`."
 
-    def __init__(self, raw):
+    def __init__(self, raw, huge_tree=False):
         self._raw = raw
         self._parsed = False
         self._root = None
         self._errors = []
+        self._huge_tree = huge_tree
 
     def __repr__(self):
         return self._raw
@@ -140,7 +141,7 @@ class RPCReply(object):
     def parse(self):
         "Parses the *rpc-reply*."
         if self._parsed: return
-        root = self._root = to_ele(self._raw) # The <rpc-reply> element
+        root = self._root = to_ele(self._raw, huge_tree=self._huge_tree) # The <rpc-reply> element
         # Per RFC 4741 an <ok/> tag is sent when there are no errors or warnings
         ok = root.find(qualify("ok"))
         if ok is None:
@@ -267,7 +268,7 @@ class RPC(object):
     "By default :class:`RPCReply`. Subclasses can specify a :class:`RPCReply` subclass."
 
 
-    def __init__(self, session, device_handler, async_mode=False, timeout=30, raise_mode=RaiseMode.NONE):
+    def __init__(self, session, device_handler, async_mode=False, timeout=30, raise_mode=RaiseMode.NONE, huge_tree=False):
         """
         *session* is the :class:`~ncclient.transport.Session` instance
 
@@ -278,6 +279,8 @@ class RPC(object):
         *timeout* is the timeout for a synchronous request, see :attr:`timeout`
 
         *raise_mode* specifies the exception raising mode, see :attr:`raise_mode`
+
+        *huge_tree* parse xml with huge_tree support (e.g. for large text config retrieval), see :attr:`huge_tree`
         """
         self._session = session
         try:
@@ -288,6 +291,7 @@ class RPC(object):
         self._async = async_mode
         self._timeout = timeout
         self._raise_mode = raise_mode
+        self._huge_tree = huge_tree
         self._id = uuid4().urn # Keeps things simple instead of having a class attr with running ID that has to be locked
         self._listener = RPCReplyListener(session, device_handler)
         self._listener.register(self._id, self)
@@ -340,7 +344,7 @@ class RPC(object):
                         else:
                             raise self._reply.error
                 if self._device_handler.transform_reply():
-                    return NCElement(self._reply, self._device_handler.transform_reply())
+                    return NCElement(self._reply, self._device_handler.transform_reply(), huge_tree=self._huge_tree)
                 else:
                     return self._reply
             else:
@@ -361,7 +365,7 @@ class RPC(object):
 
     def deliver_reply(self, raw):
         # internal use
-        self._reply = self.REPLY_CLS(raw)
+        self._reply = self.REPLY_CLS(raw, huge_tree=self._huge_tree)
         self._event.set()
 
     def deliver_error(self, err):
@@ -424,3 +428,11 @@ class RPC(object):
 
     Irrelevant for asynchronous usage.
     """
+
+    @property
+    def huge_tree(self):
+        return self._huge_tree
+
+    @huge_tree.setter
+    def huge_tree(self, x):
+        self._huge_tree = x

--- a/ncclient/operations/third_party/juniper/rpc.py
+++ b/ncclient/operations/third_party/juniper/rpc.py
@@ -12,6 +12,9 @@ class GetConfiguration(RPC):
         node = new_ele('get-configuration', {'format':format})
         if filter is not None:
             node.append(filter)
+        if format !='xml':
+            # The entire config comes as a single text element and this requires huge_tree support for large configs
+            self._huge_tree = True
         return self._request(node)
 
 class LoadConfiguration(RPC):

--- a/ncclient/xml_.py
+++ b/ncclient/xml_.py
@@ -114,7 +114,10 @@ def to_xml(ele, encoding="UTF-8", pretty_print=False):
 
 
 def to_ele(x, huge_tree=False):
-    "Convert and return the :class:`~xml.etree.ElementTree.Element` for the XML document *x*. If *x* is already an :class:`~xml.etree.ElementTree.Element` simply returns that."
+    """Convert and return the :class:`~xml.etree.ElementTree.Element` for the XML document *x*. If *x* is already an :class:`~xml.etree.ElementTree.Element` simply returns that.
+
+    *huge_tree*: parse XML with very deep trees and very long text content
+    """
     if sys.version < '3':
         return x if etree.iselement(x) else etree.fromstring(x, parser=_get_parser(huge_tree))
     else:

--- a/ncclient/xml_.py
+++ b/ncclient/xml_.py
@@ -31,6 +31,12 @@ from lxml import etree
 from ncclient import NCClientError
 
 parser = etree.XMLParser(recover=False)
+huge_parser = etree.XMLParser(recover=False, huge_tree=True)
+
+
+def _get_parser(huge_tree=False):
+    return huge_parser if huge_tree else parser
+
 
 class XMLError(NCClientError):
     pass
@@ -106,12 +112,14 @@ def to_xml(ele, encoding="UTF-8", pretty_print=False):
         return xml.decode('UTF-8') if xml.startswith(b'<?xml') \
             else '<?xml version="1.0" encoding="%s"?>%s' % (encoding, xml.decode('UTF-8'))
 
-def to_ele(x):
+
+def to_ele(x, huge_tree=False):
     "Convert and return the :class:`~xml.etree.ElementTree.Element` for the XML document *x*. If *x* is already an :class:`~xml.etree.ElementTree.Element` simply returns that."
     if sys.version < '3':
-        return x if etree.iselement(x) else etree.fromstring(x, parser=parser)
+        return x if etree.iselement(x) else etree.fromstring(x, parser=_get_parser(huge_tree))
     else:
-        return x if etree.iselement(x) else etree.fromstring(x.encode('UTF-8'), parser=parser)
+        return x if etree.iselement(x) else etree.fromstring(x.encode('UTF-8'), parser=_get_parser(huge_tree))
+
 
 def parse_root(raw):
     "Efficiently parses the root element of a *raw* XML document, returning a tuple of its qualified name and attribute dictionary."
@@ -153,9 +161,10 @@ XPATH_NAMESPACES = {
 
 
 class NCElement(object):
-    def __init__(self, result, transform_reply):
+    def __init__(self, result, transform_reply, huge_tree=False):
         self.__result = result
         self.__transform_reply = transform_reply
+        self.__huge_tree = huge_tree
         if isinstance(transform_reply, types.FunctionType):
             self.__doc = self.__transform_reply(result._root)
         else:
@@ -191,7 +200,7 @@ class NCElement(object):
     @property
     def tostring(self):
         """return a pretty-printed string output for rpc reply"""
-        parser = etree.XMLParser(remove_blank_text=True)
+        parser = etree.XMLParser(remove_blank_text=True, huge_tree=self.__huge_tree)
         outputtree = etree.XML(etree.tostring(self.__doc), parser)
         return etree.tostring(outputtree, pretty_print=True)
 
@@ -203,10 +212,12 @@ class NCElement(object):
     def remove_namespaces(self, rpc_reply):
         """remove xmlns attributes from rpc reply"""
         self.__xslt=self.__transform_reply
-        self.__parser = etree.XMLParser(remove_blank_text=True)
+        self.__parser = etree.XMLParser(remove_blank_text=True, huge_tree=self.__huge_tree)
         self.__xslt_doc = etree.parse(io.BytesIO(self.__xslt), self.__parser)
         self.__transform = etree.XSLT(self.__xslt_doc)
-        self.__root = etree.fromstring(str(self.__transform(etree.parse(StringIO(str(rpc_reply))))))
+        self.__root = etree.fromstring(str(self.__transform(etree.parse(StringIO(str(rpc_reply)),
+                                                                        parser=self.__parser))),
+                                       parser=self.__parser)
         return self.__root
 
 

--- a/test/unit/operations/test_rpc.py
+++ b/test/unit/operations/test_rpc.py
@@ -92,9 +92,7 @@ class TestRPC(unittest.TestCase):
     @patch('ncclient.transport.Session.send')
     @patch(patch_str)
     def test_rpc_send(self, mock_thread, mock_send):
-        device_handler = manager.make_device_handler({'name': 'junos'})
-        capabilities = Capabilities(device_handler.get_capabilities())
-        session = ncclient.transport.Session(capabilities)
+        device_handler, session = self._mock_device_handler_and_session()
         obj = RPC(session, device_handler, raise_mode=RaiseMode.ALL, timeout=0)
         reply = RPCReply(xml1)
         obj._reply = reply
@@ -120,9 +118,7 @@ class TestRPC(unittest.TestCase):
     @patch('ncclient.transport.Session.send')
     @patch(patch_str)
     def test_rpc_async(self, mock_thread, mock_send):
-        device_handler = manager.make_device_handler({'name': 'junos'})
-        capabilities = Capabilities(device_handler.get_capabilities())
-        session = ncclient.transport.Session(capabilities)
+        device_handler, session = self._mock_device_handler_and_session()
         obj = RPC(
             session,
             device_handler,
@@ -138,9 +134,7 @@ class TestRPC(unittest.TestCase):
     @patch('ncclient.transport.Session.send')
     @patch(patch_str)
     def test_rpc_timeout_error(self, mock_thread, mock_send):
-        device_handler = manager.make_device_handler({'name': 'junos'})
-        capabilities = Capabilities(device_handler.get_capabilities())
-        session = ncclient.transport.Session(capabilities)
+        device_handler, session = self._mock_device_handler_and_session()
         obj = RPC(session, device_handler, raise_mode=RaiseMode.ALL, timeout=0)
         reply = RPCReply(xml1)
         obj.deliver_reply(reply)
@@ -152,9 +146,7 @@ class TestRPC(unittest.TestCase):
     @patch('ncclient.transport.Session.send')
     @patch(patch_str)
     def test_rpc_rpcerror(self, mock_thread, mock_send):
-        device_handler = manager.make_device_handler({'name': 'junos'})
-        capabilities = Capabilities(device_handler.get_capabilities())
-        session = ncclient.transport.Session(capabilities)
+        device_handler, session = self._mock_device_handler_and_session()
         obj = RPC(session, device_handler, raise_mode=RaiseMode.ALL, timeout=0)
         reply = RPCReply(xml1)
         obj._reply = reply
@@ -168,11 +160,15 @@ class TestRPC(unittest.TestCase):
     @patch('ncclient.transport.Session.send')
     @patch(patch_str)
     def test_rpc_capability_error(self, mock_thread, mock_send):
-        device_handler = manager.make_device_handler({'name': 'junos'})
-        capabilities = Capabilities(device_handler.get_capabilities())
-        session = ncclient.transport.Session(capabilities)
+        device_handler, session = self._mock_device_handler_and_session()
         session._server_capabilities = [':running']
         obj = RPC(session, device_handler, raise_mode=RaiseMode.ALL, timeout=0)
         obj._assert(':running')
         self.assertRaises(MissingCapabilityError,
             obj._assert, ':candidate')
+
+    def _mock_device_handler_and_session(self):
+        device_handler = manager.make_device_handler({'name': 'junos'})
+        capabilities = Capabilities(device_handler.get_capabilities())
+        session = ncclient.transport.Session(capabilities)
+        return device_handler, session

--- a/test/unit/operations/third_party/juniper/test_rpc.py
+++ b/test/unit/operations/third_party/juniper/test_rpc.py
@@ -48,6 +48,19 @@ class TestRPC(unittest.TestCase):
 
     @patch('ncclient.transport.SSHSession')
     @patch('ncclient.operations.third_party.juniper.rpc.RPC._request')
+    def test_getconf_text_sets_huge_tree(self, mock_request, mock_session):
+        device_handler = manager.make_device_handler({'name': 'junos'})
+        session = ncclient.transport.SSHSession(device_handler)
+        obj = GetConfiguration(
+            session,
+            device_handler,
+            raise_mode=RaiseMode.ALL)
+        obj.huge_tree = False
+        obj.request(format='text')
+        self.assertTrue(obj.huge_tree)
+
+    @patch('ncclient.transport.SSHSession')
+    @patch('ncclient.operations.third_party.juniper.rpc.RPC._request')
     def test_loadconf_xml(self, mock_request, mock_session):
         device_handler = manager.make_device_handler({'name': 'junos'})
         session = ncclient.transport.SSHSession(device_handler)

--- a/test/unit/test_manager.py
+++ b/test/unit/test_manager.py
@@ -4,6 +4,7 @@ from ncclient import manager
 from ncclient.devices.junos import JunosDeviceHandler
 import logging
 
+
 class TestManager(unittest.TestCase):
 
     @patch('ncclient.transport.SSHSession')
@@ -183,6 +184,29 @@ class TestManager(unittest.TestCase):
         conn = self._mock_manager()
         self.assertEqual(conn.connected, True)
 
+    @patch('ncclient.manager.Manager.HUGE_TREE_DEFAULT')
+    @patch('ncclient.transport.SSHSession')
+    @patch('ncclient.operations.rpc.RPC')
+    def test_manager_huge_node(self, mock_rpc, mock_session, default_value):
+
+        # Set default value to True only in this test through the default_value mock
+        default_value = True
+
+        # true should propagate all the way to the RPC
+        conn = self._mock_manager()
+        self.assertTrue(conn.huge_tree)
+        conn.execute(mock_rpc)
+        mock_rpc.assert_called_once()
+        self.assertTrue(mock_rpc.call_args[1]['huge_tree'])
+
+        # false should propagate all the way to the RPC
+        conn.huge_tree = False
+        self.assertFalse(conn.huge_tree)
+        mock_rpc.reset_mock()
+        conn.execute(mock_rpc)
+        mock_rpc.assert_called_once()
+        self.assertFalse(mock_rpc.call_args[1]['huge_tree'])
+
     def _mock_manager(self):
         conn = manager.connect(host='10.10.10.10',
                                     port=22,
@@ -211,6 +235,7 @@ class TestManager(unittest.TestCase):
                                     device_params={'name': 'junos'},
                                     hostkey_verify=False, allow_agent=False)
         return conn
+
 
 if __name__ == "__main__":
     suite = unittest.TestLoader().loadTestsFromTestCase(TestManager)

--- a/test/unit/test_manager.py
+++ b/test/unit/test_manager.py
@@ -67,7 +67,6 @@ class TestManager(unittest.TestCase):
                                     port=830,
                                     username='user',
                                     password='password',
-                                    timeout=10,
                                     hostkey_verify=False,
                                     allow_agent=False,
                                     ssh_config=ssh_config_path)
@@ -209,7 +208,6 @@ class TestManager(unittest.TestCase):
                                     sock_fd=6,
                                     username='user',
                                     password='password',
-                                    timeout=10,
                                     device_params={'name': 'junos'},
                                     hostkey_verify=False, allow_agent=False)
         return conn


### PR DESCRIPTION
Fixes #185 

This merge request adds a `huge_tree` paramater for the "Manager", which can be tweaked in multiple places:
* global level `manager.Manager.HUGE_TREE_DEFAULT`, in case the library is used by another library that cannot be modfied
* as a property for the `Manager` (the solution suggested in #186)
* at the RPC implementation level (e.g. `third_party.juniper.rpc.GetConfiguration` enables huge_tree support for non-xml configuration formats)

Note, that at least for lxml for Python 3.6, the xml parsing of `huge text node` is not triggered for huge text nodes that do not contain XML escaped characters (e.g. `&gt;` for `>`).