### PR TITLE
Allow source address for SSH connection

### DIFF
--- a/docs/source/transport.rst
+++ b/docs/source/transport.rst
@@ -22,7 +22,7 @@ SSH session implementation
     :show-inheritance:
     :members: load_known_hosts, close, transport
 
-    .. automethod:: connect(host[, port=830, timeout=None, unknown_host_cb=default_unknown_host_cb, username=None, password=None, key_filename=None, allow_agent=True, hostkey_verify=True, hostkey=None, look_for_keys=True, ssh_config=None])
+    .. automethod:: connect(host[, port=830, timeout=None, unknown_host_cb=default_unknown_host_cb, username=None, password=None, key_filename=None, allow_agent=True, hostkey_verify=True, hostkey=None, look_for_keys=True, ssh_config=None, bind_addr=None])
 
 Errors
 ------

--- a/ncclient/transport/ssh.py
+++ b/ncclient/transport/ssh.py
@@ -306,7 +306,8 @@ class SSHSession(Session):
             hostkey_b64         = None,
             look_for_keys       = True,
             ssh_config          = None,
-            sock_fd             = None):
+            sock_fd             = None,
+            bind_addr           = None):
 
         """Connect via SSH and initialize the NETCONF session. First attempts the publickey authentication method and then password authentication.
 
@@ -337,6 +338,8 @@ class SSHSession(Session):
         *ssh_config* enables parsing of an OpenSSH configuration file, if set to its path, e.g. :file:`~/.ssh/config` or to True (in this case, use :file:`~/.ssh/config`).
 
         *sock_fd* is an already open socket which shall be used for this connection. Useful for NETCONF outbound ssh. Use host=None together with a valid sock_fd number
+
+        *bind_addr* is a (local) source IP address to use, must be reachable from the remote device.
         """
         if not (host or sock_fd):
             raise SSHError("Missing host or socket fd")
@@ -401,6 +404,8 @@ class SSHSession(Session):
                     except socket.error:
                         continue
                     try:
+                        if bind_addr:
+                            sock.bind((bind_addr, 0))
                         sock.connect(sa)
                     except socket.error:
                         sock.close()


### PR DESCRIPTION
If the client device has multiple IP interfaces, in some cases the SSH connect attempts to use a local address that can’t be reached by the remote host. This results in failure to establish an SSH connection.
 
The fix is trivial: allow the caller to optionally pass a source address when connecting to the netconf host. This, in turn, is used in the socket.bind().