### PR TITLE
fix: "Too many open files" for Junos devices 

### DIFF
--- a/ncclient/transport/third_party/junos/ioproc.py
+++ b/ncclient/transport/third_party/junos/ioproc.py
@@ -36,7 +36,7 @@ class IOProc(SSHSession):
         self._device_handler = device_handler
 
     def close(self):
-        self._channel.wait()
+        stdout, stderr = self._channel.communicate()
         self._channel = None
         self._connected = False
 


### PR DESCRIPTION
* Junos specific changes

Use subprocess `communicate` in place of a `wait` so that there is a clean up of buffer and it closes the process connection.