### PR TITLE
Fix the order of operations in edit-config

### DIFF
--- a/ncclient/operations/edit.py
+++ b/ncclient/operations/edit.py
@@ -45,16 +45,16 @@ class EditConfig(RPC):
         """
         node = new_ele("edit-config")
         node.append(util.datastore_or_url("target", target, self._assert))
+        if default_operation is not None:
+        # TODO: check if it is a valid default-operation
+            sub_ele(node, "default-operation").text = default_operation
+        if test_option is not None:
+            self._assert(':validate')
+            sub_ele(node, "test-option").text = test_option
         if error_option is not None:
             if error_option == "rollback-on-error":
                 self._assert(":rollback-on-error")
             sub_ele(node, "error-option").text = error_option
-        if test_option is not None:
-            self._assert(':validate')
-            sub_ele(node, "test-option").text = test_option
-        if default_operation is not None:
-        # TODO: check if it is a valid default-operation
-            sub_ele(node, "default-operation").text = default_operation
 # <<<<<<< HEAD
 #         node.append(validated_element(config, ("config", qualify("config"))))
 # =======

--- a/test/unit/operations/test_edit.py
+++ b/test/unit/operations/test_edit.py
@@ -56,9 +56,9 @@ class TestEdit(unittest.TestCase):
                     default_operation="default", test_option="test")
         node = new_ele("edit-config")
         node.append(util.datastore_or_url("target", "running"))
-        sub_ele(node, "error-option").text = "rollback-on-error"
-        sub_ele(node, "test-option").text = "test"
         sub_ele(node, "default-operation").text = "default"
+        sub_ele(node, "test-option").text = "test"
+        sub_ele(node, "error-option").text = "rollback-on-error"
         config_text = sub_ele(node, "config-text")
         sub_ele(config_text, "configuration-text").text = root
         xml = ElementTree.tostring(node)


### PR DESCRIPTION
NETCONF edit-config expects default-operation first and then test and
error option, otherwise libnetconf2 throws below error.

"Invalid order of elements "default-operation" and "error-option".
(/ietf-netconf:edit-config/default-operation)"

the order as per ietf-netconf.yang is
- default_operation
- test_option
- error_option