### PR TITLE
add "update" RPC.

### DIFF
--- a/ncclient/devices/huawei.py
+++ b/ncclient/devices/huawei.py
@@ -38,6 +38,7 @@ class HuaweiDeviceHandler(DefaultDeviceHandler):
         dict = {}
         dict["cli"] = CLI
         dict["action"] = Action
+        dict["update"] = Update
         return dict
 
     def handle_raw_dispatch(self, raw):
@@ -51,6 +52,7 @@ class HuaweiDeviceHandler(DefaultDeviceHandler):
         c.append('http://www.huawei.com/netconf/capability/active/1.0')
         c.append('http://www.huawei.com/netconf/capability/discard-commit/1.0')
         c.append('http://www.huawei.com/netconf/capability/exchange/1.0')
+        c.append('http://www.huawei.com/netconf/capability/update/1.0')
         
         return c
 

--- a/ncclient/operations/third_party/huawei/rpc.py
+++ b/ncclient/operations/third_party/huawei/rpc.py
@@ -25,3 +25,17 @@ class Action(RPC):
         node = new_ele("execute-action", attrs={"xmlns":HW_PRIVATE_NS})
         node.append(validated_element(action))
         return self._request(node)
+
+
+class Update(RPC):
+    """
+    update configure or update candidate DB to running DB.
+    """
+    def request(self, candidate=True):
+        if candidate:
+            node = new_ele("commit")
+            update = new_ele("update-candidate", attrs={"xmlns":HW_PRIVATE_NS})
+            node.append(update)
+        else:
+            node = new_ele("update ", attrs={"xmlns":HW_PRIVATE_NS})
+        return self._request(node)


### PR DESCRIPTION

## Capability identification.
```
<capability>http://www.huawei.com/netconf/capability/update/1.0</capability>
```
## Support message triggering update configuration operation.
### RPC Request
```
<rpc message-id="101" xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
  <update xmlns="http://www.huawei.com/netconf/capability/base/1.0"/>
</rpc>
```
### RPC Response
```
<rpc-reply message-id="101" xmlns="urn:ietf:params:xml:ns:netconf:base:1.0"> 
  <ok/>
</rpc-reply>
```
## Support for updating the configuration data in the current <candidate/> database to the <running/> database via the <update> operation when a conflict occurs during configuration submission.
### RPC Request
```
<rpc message-id="2" xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
  <commit>
    <update-candidate xmlns="http://www.huawei.com/netconf/capability/base/1.0"/>
  </commit>
</rpc>
```
### RPC Response
```
<rpc-reply message-id="2" xmlns="urn:ietf:params:xml:ns:netconf:base:1.0"> 
  <ok/>
</rpc-reply>
````