### PR TITLE
Create NOTICE

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,4 @@
+ncclient
+Copyright (c) 2019 Cisco Systems, Inc. and/or its affiliates
+
+This project includes software developed at Cisco Systems, Inc. and/or its affiliates.

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
 ncclient
-Copyright (c) 2019 Cisco Systems, Inc. and/or its affiliates
+Portions Copyright (c) 2019 Cisco Systems, Inc. and/or its affiliates
 
 This project includes software developed at Cisco Systems, Inc. and/or its affiliates.


### PR DESCRIPTION
When using Apache 2.0 as the license, the copyright notice is not in the LICENSE file itself. Instead, the Apache A NOTICE file is a common way to capture this information (see http://www.apache.org/dev/apply-license.html#new)