### PR TITLE
Add base:1.1 capability to huaweiyang -device handler

### DIFF
--- a/ncclient/devices/huaweiyang.py
+++ b/ncclient/devices/huaweiyang.py
@@ -35,6 +35,7 @@ class HuaweiyangDeviceHandler(DefaultDeviceHandler):
         # Just need to replace a single value in the default capabilities
         c = []
         c.append('urn:ietf:params:netconf:base:1.0')
+        c.append('urn:ietf:params:netconf:base:1.1')
         
         return c
 


### PR DESCRIPTION
Add `urn:ietf:params:netconf:base:1.1` -capability to huaweiyang -device handler.

This allow's usage of Netconf 1.1 -features(eg. remove -operation) against Huawei devices with latest SW.