### PR TITLE
added support for persist-id element in the commit RPC

### DIFF
--- a/ncclient/operations/edit.py
+++ b/ncclient/operations/edit.py
@@ -18,6 +18,8 @@ from ncclient.operations.rpc import RPC
 
 from ncclient.operations import util
 
+from .errors import OperationError
+
 import logging
 
 logger = logging.getLogger("ncclient.operations.edit")
@@ -147,6 +149,8 @@ class Commit(RPC):
         *persist_id* value must be equal to the value given in the <persist> parameter to the original <commit> operation.
         """
         node = new_ele("commit")
+        if (confirmed or persist) and persist_id:
+            raise OperationError("Invalid operation as confirmed or persist cannot be present with persist-id")
         if confirmed:
             self._assert(":confirmed-commit")
             sub_ele(node, "confirmed")
@@ -154,7 +158,7 @@ class Commit(RPC):
                 sub_ele(node, "confirm-timeout").text = timeout
             if persist is not None:
                 sub_ele(node, "persist").text = persist
-        if not (confirmed and persist) and persist_id:
+        if persist_id:
             sub_ele(node, "persist-id").text = persist_id
 
         return self._request(node)

--- a/ncclient/operations/edit.py
+++ b/ncclient/operations/edit.py
@@ -133,7 +133,7 @@ class Commit(RPC):
 
     DEPENDS = [':candidate']
 
-    def request(self, confirmed=False, timeout=None, persist=None):
+    def request(self, confirmed=False, timeout=None, persist=None, persist_id=None):
         """Commit the candidate configuration as the device's new current configuration. Depends on the `:candidate` capability.
 
         A confirmed commit (i.e. if *confirmed* is `True`) is reverted if there is no followup commit within the *timeout* interval. If no timeout is specified the confirm timeout defaults to 600 seconds (10 minutes). A confirming commit may have the *confirmed* parameter but this is not required. Depends on the `:confirmed-commit` capability.
@@ -143,6 +143,8 @@ class Commit(RPC):
         *timeout* specifies the confirm timeout in seconds
 
         *persist* make the confirmed commit survive a session termination, and set a token on the ongoing confirmed commit
+
+        *persist_id* value must be equal to the value given in the <persist> parameter to the original <commit> operation.
         """
         node = new_ele("commit")
         if confirmed:
@@ -152,6 +154,8 @@ class Commit(RPC):
                 sub_ele(node, "confirm-timeout").text = timeout
             if persist is not None:
                 sub_ele(node, "persist").text = persist
+        if not (confirmed and persist) and persist_id:
+            sub_ele(node, "persist-id").text = persist_id
 
         return self._request(node)
 


### PR DESCRIPTION
Added support for persist-id element as discussed in the https://github.com/ncclient/ncclient/issues/357