### PR TITLE
NameError instead of SSHUnknownHostError in case of failed known_hosts verification - bugfix

### DIFF
--- a/ncclient/transport/ssh.py
+++ b/ncclient/transport/ssh.py
@@ -349,7 +349,7 @@ class SSHSession(Session):
                 is_known_host = any(self._host_keys.check(lookup, server_key_obj) for lookup in known_hosts_lookups)
 
             if not is_known_host and not unknown_host_cb(host, fingerprint):
-                raise SSHUnknownHostError(known_hosts_lookup[0], fingerprint)
+                raise SSHUnknownHostError(known_hosts_lookups[0], fingerprint)
 
         # Authenticating with our private key/identity
         if key_filename is None:


### PR DESCRIPTION
In case of failed known_host verification attempt of raising SSHUnknownHostError was performed. Problem was that for SSHUnknownHostError object creation "known_hosts_lookup" variable was used in the code but this variable doesn't exist (typo - proper name: "known_hosts_lookups"). Result was strange NameError and time spent on investigation ;) 