### PR TITLE
Fix error due to use of private paramiko class attribute

### DIFF
--- a/ncclient/transport/ssh.py
+++ b/ncclient/transport/ssh.py
@@ -322,7 +322,7 @@ class SSHSession(Session):
             host_port = '[%s]:%s' % (host, port)
             known_host_keys_for_this_host.update(self._host_keys.lookup(host_port) or {})
             if known_host_keys_for_this_host:
-                self._transport._preferred_keys = [x.key.get_name() for x in known_host_keys_for_this_host._entries]
+                self._transport._preferred_keys = list(known_host_keys_for_this_host)
 
         # Connect
         try:


### PR DESCRIPTION
This code relies on the internal mapping class in Paramiko, but the variable might hold a normal Python dictionary due to the previous lines, so it crashes when `self._host_keys.lookup(host_port)` is true. The keys to this virtual dictionary are already "x.key.get_name()", so it can be simplified to iterating over it.