### PR TITLE
Allow for follow-up confirmed commit with persist-id

### DIFF
--- a/ncclient/operations/edit.py
+++ b/ncclient/operations/edit.py
@@ -149,8 +149,8 @@ class Commit(RPC):
         *persist_id* value must be equal to the value given in the <persist> parameter to the original <commit> operation.
         """
         node = new_ele("commit")
-        if (confirmed or persist) and persist_id:
-            raise OperationError("Invalid operation as confirmed or persist cannot be present with persist-id")
+        if persist and persist_id:
+            raise OperationError("Invalid operation as persist cannot be present with persist-id")
         if confirmed:
             self._assert(":confirmed-commit")
             sub_ele(node, "confirmed")


### PR DESCRIPTION
From the following in section 8.4 of the RFC - https://tools.ietf.org/html/rfc6241#section-8.4 -
```
   A confirmed <commit> operation MUST be reverted if a confirming
   commit is not issued within the timeout period (by default 600
   seconds = 10 minutes).  The confirming commit is a <commit> operation
   without the <confirmed> parameter.  The timeout period can be
   adjusted with the <confirm-timeout> parameter.  If a follow-up
   confirmed <commit> operation is issued before the timer expires, the
   timer is reset to the new value (600 seconds by default).  Both the
   confirming commit and a follow-up confirmed <commit> operation MAY
   introduce additional changes to the configuration.

   If the <persist> element is not given in the confirmed commit
   operation, any follow-up commit and the confirming commit MUST be
   issued on the same session that issued the confirmed commit.  If the
   <persist> element is given in the confirmed <commit> operation, a
   follow-up commit and the confirming commit can be given on any
   session, and they MUST include a <persist-id> element with a value
   equal to the given value of the <persist> element.
```
I have a test which has the work flow:

- Create Netconf Session
- Then Send Test Configuration
- And Send Confirmed Commit timeout=30 persist=TestPersist
- Then Send More Test Configuration
- And Send Confirmed Commit timeout=30 persist-id=TestPersist
- And Send Commit persist-id=TestPersist
- Disconnect Netconf Session

I believe this is valid based on the RFC, however I am getting the following:

`Calling method 'commit' failed: OperationError: Invalid operation as confirmed or persist cannot be present with persist-id`

When sending the second confirmed commit after sending the second set of changes to the configuration.
This fix makes it possible for persist-id to be used to issue a follow-up confirmed commit or a confirming commit from any session, with the token from the previous <commit> operation. Rather than just in a confirming commit.
