### PR TITLE
Bugfix #176 sub_ele should inherit parent namespace

### DIFF
--- a/ncclient/xml_.py
+++ b/ncclient/xml_.py
@@ -224,10 +224,8 @@ class NCElement(object):
         return self.__root
 
 def parent_ns(node):
-    index1 = node.tag.find('{')
-    index2 = node.tag.find('}')
-    if index1 != -1 and index2 != -1 and index1 < index2:
-        return node.tag[index1+1: index2]
+    if node.prefix:
+        return node.nsmap[node.prefix]
     return None
 
 new_ele = lambda tag, attrs={}, **extra: etree.Element(qualify(tag), attrs, **extra)

--- a/ncclient/xml_.py
+++ b/ncclient/xml_.py
@@ -223,11 +223,17 @@ class NCElement(object):
                                        parser=self.__parser)
         return self.__root
 
+def parent_ns(node):
+    index1 = node.tag.find('{')
+    index2 = node.tag.find('}')
+    if index1 != -1 and index2 != -1 and index1 < index2:
+        return node.tag[index1+1: index2]
+    return None
 
 new_ele = lambda tag, attrs={}, **extra: etree.Element(qualify(tag), attrs, **extra)
 
 new_ele_ns = lambda tag, ns, attrs={}, **extra: etree.Element(qualify(tag,ns), attrs, **extra)
 
-sub_ele = lambda parent, tag, attrs={}, **extra: etree.SubElement(parent, qualify(tag), attrs, **extra)
+sub_ele = lambda parent, tag, attrs={}, **extra: etree.SubElement(parent, qualify(tag, parent_ns(parent)), attrs, **extra)
 
 sub_ele_ns = lambda parent, tag, ns, attrs={}, **extra: etree.SubElement(parent, qualify(tag, ns), attrs, **extra)

--- a/test/unit/test_xml_.py
+++ b/test/unit/test_xml_.py
@@ -176,3 +176,16 @@ class TestXML(unittest.TestCase):
         result_xml = result.data_xml
         self.assertRaises(XMLError,
             validated_element, result_xml, tags=["rpc"])
+
+    def test_sub_ele_inherit_parent_namespace(self):
+        device_params = {'name': 'junos'}
+        device_handler = manager.make_device_handler(device_params)
+        transform_reply = device_handler.transform_reply()
+        result = NCElement(self.reply, transform_reply)
+        ele = new_ele_ns(result.find("./cli").tag, "http://www.xxx.org")
+        child = sub_ele(ele, "child")
+        sibling = sub_ele(ele, "sibling")
+        grandchild = sub_ele(child, "grandchild")
+        self.assertEqual(child.tag, "{http://www.xxx.org}child")
+        self.assertEqual(sibling.tag, "{http://www.xxx.org}sibling")
+        self.assertEqual(grandchild.tag, "{http://www.xxx.org}grandchild")


### PR DESCRIPTION
This PR resolves the second of issue #176. it means let sub_ele inherit parent namespace per default