### PR TITLE
Refactor the manager_params doesn't be used in class Manager init()

### DIFF
--- a/ncclient/manager.py
+++ b/ncclient/manager.py
@@ -137,7 +137,7 @@ def connect_ssh(*args, **kwds):
         if session.transport:
             session.close()
         raise
-    return Manager(session, device_handler, **manager_params)
+    return Manager(session, device_handler, manager_params=manager_params)
 
 
 def connect_ioproc(*args, **kwds):
@@ -154,7 +154,7 @@ def connect_ioproc(*args, **kwds):
     session = third_party_import.IOProc(device_handler)
     session.connect()
 
-    return Manager(session, device_handler, **manager_params)
+    return Manager(session, device_handler, manager_params=manager_params)
 
 
 def connect(*args, **kwds):
@@ -194,12 +194,13 @@ class Manager(object):
     HUGE_TREE_DEFAULT = False
     """Default for `huge_tree` support for XML parsing of RPC replies (defaults to False)"""
 
-    def __init__(self, session, device_handler, timeout=30):
+    def __init__(self, session, device_handler, **kwargs):
+        manager_params = kwargs.get("manager_params", {})
         self._session = session
-        self._async_mode = False
-        self._timeout = timeout
-        self._raise_mode = operations.RaiseMode.ALL
-        self._huge_tree = self.HUGE_TREE_DEFAULT
+        self._async_mode = manager_params.get("async_mode", False)
+        self._timeout = manager_params.get("timeout", 30)
+        self._raise_mode = manager_params.get("raise_mode", operations.RaiseMode.ALL)
+        self._huge_tree = manager_params.get("huge_tree", self.HUGE_TREE_DEFAULT)
         self._device_handler = device_handler
         self._vendor_operations = {}
         if device_handler:

--- a/test/unit/test_manager.py
+++ b/test/unit/test_manager.py
@@ -108,7 +108,7 @@ class TestManager(unittest.TestCase):
         manager.connect(host='localhost', device_params={'name': 'junos', 
                                                         'local': True})
         mock_ssh.assert_called_once_with(host='localhost', 
-                            device_params={'local': True, 'name': 'junos'})
+                                         device_params={'local': True, 'name': 'junos'})
 
     @patch('paramiko.proxy.ProxyCommand')
     @patch('paramiko.Transport')
@@ -119,12 +119,12 @@ class TestManager(unittest.TestCase):
         ssh_config_path = 'test/unit/ssh_config'
 
         conn = manager.connect(host='fake_host',
-                                    port=830,
-                                    username='user',
-                                    password='password',
-                                    hostkey_verify=False,
-                                    allow_agent=False,
-                                    ssh_config=ssh_config_path)
+                               port=830,
+                               username='user',
+                               password='password',
+                               hostkey_verify=False,
+                               allow_agent=False,
+                               ssh_config=ssh_config_path)
 
         log.debug(mock_proxy.call_args[0][0])
         self.assertEqual(mock_proxy.called, 1)
@@ -147,19 +147,35 @@ class TestManager(unittest.TestCase):
     @patch('ncclient.transport.third_party.junos.ioproc.IOProc.connect')
     def test_ioproc(self, mock_connect, mock_ioproc):
         conn = manager.connect(host='localhost',
-                                    port=22,
-                                    username='user',
-                                    password='password',
-                                    timeout=3,
-                                    hostkey_verify=False,
-                                    device_params={'local': True, 'name': 'junos'},
-                                    manager_params={'timeout': 10})
+                               port=22,
+                               username='user',
+                               password='password',
+                               timeout=3,
+                               hostkey_verify=False,
+                               device_params={'local': True, 'name': 'junos'},
+                               manager_params={'timeout': 10})
         self.assertEqual(mock_connect.called, 1)
         self.assertEqual(conn._timeout, 10)
         self.assertEqual(conn._device_handler.device_params, {'local': True, 'name': 'junos'}) 
         self.assertEqual(
             conn._device_handler.__class__.__name__,
             "JunosDeviceHandler")
+
+    @patch('ncclient.transport.SSHSession')
+    def test_make_manager_params(self, mock_ssh):
+        conn = manager.connect(host='fake_host',
+                               port=830,
+                               username='user',
+                               password='password',
+                               hostkey_verify=False,
+                               allow_agent=False,
+                               manager_params={'huge_tree': True,
+                                               'async_mode': True,
+                                               'timeout': 20})
+        self.assertEqual(conn.timeout, 20)
+        self.assertTrue(conn.huge_tree)
+        self.assertTrue(conn.async_mode)
+
 
     def test_make_device_handler(self):
         device_handler = manager.make_device_handler({'name': 'junos'})
@@ -263,13 +279,13 @@ class TestManager(unittest.TestCase):
 
     def _mock_manager(self):
         conn = manager.connect(host='10.10.10.10',
-                                    port=22,
-                                    username='user',
-                                    password='password',
-                                    timeout=3,
-                                    hostkey_verify=False, allow_agent=False,
-                                    device_params={'name': 'junos'},
-                                    manager_params={'timeout': 10})
+                               port=22,
+                               username='user',
+                               password='password',
+                               timeout=3,
+                               hostkey_verify=False, allow_agent=False,
+                               device_params={'name': 'junos'},
+                               manager_params={'timeout': 10})
         return conn
 
     @patch('socket.fromfd')
@@ -283,11 +299,11 @@ class TestManager(unittest.TestCase):
 
     def _mock_outbound_manager(self):
         conn = manager.connect(host=None,
-                                    sock_fd=6,
-                                    username='user',
-                                    password='password',
-                                    device_params={'name': 'junos'},
-                                    hostkey_verify=False, allow_agent=False)
+                               sock_fd=6,
+                               username='user',
+                               password='password',
+                               device_params={'name': 'junos'},
+                               hostkey_verify=False, allow_agent=False)
         return conn
 
 


### PR DESCRIPTION
@einarnn Hi,
This PR fixes the parameter `manager_params` that is not used in class Manager initialization.

The implement of connect_ssh:
```
def connect_ssh(*args, **kwds):
    ......
    device_params = _extract_device_params(kwds)
    manager_params = _extract_manager_params(kwds)

    device_handler = make_device_handler(device_params)
    device_handler.add_additional_ssh_connect_params(kwds)
    session = transport.SSHSession(device_handler)
    if "hostkey_verify" not in kwds or kwds["hostkey_verify"]:
        session.load_known_hosts()

    try:
       session.connect(*args, **kwds)
    except Exception as ex:
        if session.transport:
            session.close()
        raise
    return Manager(session, device_handler, **manager_params)
```

The implement of connect_ioproc:
```
def connect_ioproc(*args, **kwds):
    device_params = _extract_device_params(kwds)
    manager_params = _extract_manager_params(kwds)

    if device_params:
        import_string = 'ncclient.transport.third_party.'
        import_string += device_params['name'] + '.ioproc'
        third_party_import = __import__(import_string, fromlist=['IOProc'])

    device_handler = make_device_handler(device_params)

    session = third_party_import.IOProc(device_handler)
    session.connect()

    return Manager(session, device_handler, **manager_params)
```
As seen above, both `connect_ssh` and `connect_ioproc` return a Manager object with the `manager_params` parameter. However,
This parameter is not used in class Manager initialization.

https://github.com/ncclient/ncclient/blob/3380f1140791f4a8de5d303f919f1e4cc9532f32/ncclient/manager.py#L197-L206