### PR TITLE
Modify asyncio interface based on PR #76

### DIFF
--- a/examples/asyncio_example.py
+++ b/examples/asyncio_example.py
@@ -1,0 +1,66 @@
+#! /usr/bin/env python
+#
+# Connect to the NETCONF server passed on the command line, and
+# setting async mode ensures that the RPC.request() only sends
+# the request and does not wait synchronously for a response.
+# This script and the following scripts all assume that the user
+# calling the script is known by the server and that suitable
+# SSH keys are in place. For brevity and clarity of example,
+# we omit proper exception handling.
+#
+# $ ./asyncio_example.py host user password
+
+from ncclient import manager
+import logging, asyncio, sys
+
+filter1 = '''
+    <top xmlns="xxx.org">
+      <name/>
+    </top>
+    '''
+
+filter2 = '''
+    <top xmlns="xxx.org">
+      <host/>
+    </top>
+    '''
+
+filter3 = '''<top xmlns="xxx.org"/>'''
+
+def connect(host, user, password):
+    return manager.connect(
+        host=host,
+        port=22,
+        username=user,
+        password=password,
+        device_params={'name': 'junos'},
+        async_mode=True,
+        timeout=10,
+        hostkey_verify=False)
+
+
+async def multi_operations(loop, conn):
+    # the requests to be sent by the client 
+    req = [
+        conn.get_config(source='running', filter=('subtree', filter1)),
+        conn.get(filter=('subtree', filter2)),
+        conn.get_config(source='running', filter=('subtree', filter3)),
+        conn.lock(target='running'),
+        conn.lock(target='running'),
+        ]
+
+    # add asynchronously all requests to asyncio.BaseEventloop
+    tasks = [loop.create_task(r) for r in req]
+    # waiting for all responses from the server
+    dones = await asyncio.gather(*tasks)
+    for i in dones:
+        print("result: %s" % i)
+ 
+def demo(host, user, password):
+    conn = connect(host, user, password)
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(multi_operations(loop, conn))
+    loop.close()
+
+if __name__ == "__main__":
+    demo(sys.argv[1], sys.argv[2], sys.argv[3])

--- a/ncclient/async_manager.py
+++ b/ncclient/async_manager.py
@@ -1,0 +1,136 @@
+# Copyright 2015 Austin Cormier
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import functools
+import logging
+from ncclient.sync_manager import Manager
+
+logger = logging.getLogger('ncclient.asyncio_manager')
+
+
+def add_rpc_asyncio_event_support(rpc, loop):
+    """ Patch the RPC class in order to use an asyncio.Event
+    Create an asyncio.Event which is bound to the event loop. Patch the
+    existing RPC._event.set so that it invokes the set() (thread-safely)
+    on the newly created asyncio event.
+    The only two methods that set the RPC._event attribute are
+    RPC.deliver_reply and RPC.deliver_error.  After patching
+    when they attempt to set the Event, our wait() coroutine will awaken.
+    Arguments:
+        rpc - An RPC instance
+        loop - The asyncio loop to create the asyncio.Event on
+    Returns:
+        The created asyncio.Event
+    """
+    event = asyncio.Event(loop=loop)
+
+    def set_asyncio_event():
+        logger.debug("Setting asyncio.Event flag")
+        loop.call_soon_threadsafe(event.set)
+
+    rpc.event.set = set_asyncio_event
+
+    return event
+
+class AsyncioManager(Manager):
+    """ This class provides an ayncio interface which is subclassed from ncclient.Manager
+    This class attempts to take advantage of the ncclient async_mode features to
+    provide a complete asyncio interface which maps directory to the existing
+    Manager interface.  All blocking operations are wrapped in coroutines.
+    """
+    def __init__(self, session, device_handler=None, loop=None):
+        """ Create a AyncIOManager instanace
+        Arguments:
+            session - The connected SSHSession instance
+            device_handler - DeviceHandler instance
+            loop - asyncio.BaseEventLoop instance
+        """
+        super().__init__(
+            session=session,
+            device_handler=device_handler,
+        )
+
+        # Setting async mode ensures that the RPC.request() only sends
+        # the request and does not wait synchronously for a response.
+        self.async_mode = True
+
+        self._loop = loop if loop is not None else asyncio.get_event_loop()
+
+    async def execute(self, cls, *args, **kwargs):
+        """ Execute the netconf operation
+        All Manager operations are wrappers around execute
+        (see manager.py:OpExecutor()). This follows the same approach
+        as request when creating the request (the cls() call).
+        After creating the request object we patch the RPC instance (rpc.py) so
+        that the event uses the asyncio.Event intead of Threading.Event.
+        This allows us to use the asyncio.Event.wait() coroutine to wait until
+        the request is completed.
+        The only two methods that then interact with the RPC _event attribute is
+        RPC.deliver_event and RPC.deliver_error.
+        Arguments:
+            cls - The RPC operation subclass (see manager.py:OPERATIONS)
+            *args - Positional arguments to pass into RPC.request
+            **kwargs - Keyword arguments to pass into RPC.request
+        """
+        rpc = cls(self.session,
+                  device_handler=self._device_handler,
+                  async_mode=self._async_mode,
+                  timeout=self._timeout,
+                  raise_mode=self._raise_mode,
+                  huge_tree=self._huge_tree)
+
+        event = add_rpc_asyncio_event_support(rpc, self._loop)
+
+        # Start the request
+        rpc.request(*args, **kwargs)
+
+        # Wrap the Event.wait() coroutine in a wait_for() to give
+        # the ability to time-out if request doesn't complete in a reasonable
+        # amount of time.
+        await asyncio.wait_for(
+                event.wait(),
+                timeout=self._timeout,
+                loop=self._loop,
+                )
+
+        # If an error was set, then re-raise so the exeception will
+        # propogate up the stack.
+        if rpc.error is not None:
+            raise rpc.error
+
+        return rpc.reply
+
+
+async def asyncio_connect(loop=None, handler=None, *args, **kwargs):
+    """ Wraps synchronous ncclient.manager.connect within a coroutine
+    Once the Manager.connect() returns with a Manager instance, create
+    an equivelent AsyncioManager instance with the now connected session.
+    Arguments:
+        loop - asyncio.BaseEventLoop instance
+        *args - Positional arguments into Manager.connect
+        **kwargs - Keyword arguments into Manager.connect
+     Returns:
+        An AsyncioManager instance
+    """
+
+    loop = loop if loop is not None else asyncio.get_event_loop()
+    mgr = await loop.run_in_executor(
+        executor=None,
+        func=functools.partial(handler, *args, **kwargs))
+
+    return AsyncioManager(mgr.session,
+                          mgr.device_handler,
+                          loop=loop)
+

--- a/ncclient/manager.py
+++ b/ncclient/manager.py
@@ -18,44 +18,17 @@ This module is a thin layer of abstraction around the library.
 It exposes all core functionality.
 """
 
-from ncclient import operations
+from ncclient.sync_manager import Manager
 from ncclient import transport
 import socket
 import logging
-import functools
+import sys
 
-from ncclient.xml_ import *
+if sys.version_info.major > 2:
+    from asyncio import *
+    from ncclient.async_manager import asyncio_connect
 
 logger = logging.getLogger('ncclient.manager')
-
-OPERATIONS = {
-    "get": operations.Get,
-    "get_config": operations.GetConfig,
-    "get_schema": operations.GetSchema,
-    "dispatch": operations.Dispatch,
-    "edit_config": operations.EditConfig,
-    "copy_config": operations.CopyConfig,
-    "validate": operations.Validate,
-    "commit": operations.Commit,
-    "discard_changes": operations.DiscardChanges,
-    "cancel_commit": operations.CancelCommit,
-    "delete_config": operations.DeleteConfig,
-    "lock": operations.Lock,
-    "unlock": operations.Unlock,
-    "create_subscription": operations.CreateSubscription,
-    "close_session": operations.CloseSession,
-    "kill_session": operations.KillSession,
-    "poweroff_machine": operations.PoweroffMachine,
-    "reboot_machine": operations.RebootMachine,
-}
-
-"""
-Dictionary of base method names and corresponding :class:`~ncclient.operations.RPC`
-subclasses. It is used to lookup operations, e.g. `get_config` is mapped to
-:class:`~ncclient.operations.GetConfig`. It is thus possible to add additional
-operations to the :class:`Manager` API.
-"""
-
 
 def make_device_handler(device_params):
     """
@@ -140,7 +113,6 @@ def connect_ssh(*args, **kwds):
         raise
     return Manager(session, device_handler, **manager_params)
 
-
 def connect_ioproc(*args, **kwds):
     device_params = _extract_device_params(kwds)
     manager_params = _extract_manager_params(kwds)
@@ -157,8 +129,24 @@ def connect_ioproc(*args, **kwds):
 
     return Manager(session, device_handler, **manager_params)
 
-
 def connect(*args, **kwds):
+    # use sync_mode by default
+    mode = kwds.pop("async_mode", False)
+    if mode is True and sys.version_info.major > 2:
+        return async_connect(*args, **kwds)
+    else:
+        return sync_connect(*args, **kwds)
+
+def async_connect(*args, **kwds):
+    loop = get_event_loop()
+    task = loop.create_task(asyncio_connect(loop=loop, handler=sync_connect, *args, **kwds))
+    try:
+        return loop.run_until_complete(task)
+    except Exception as e:
+        loop.close()
+        raise
+
+def sync_connect(*args, **kwds):
     if "host" in kwds:
         host = kwds["host"]
         device_params = kwds.get('device_params', {})
@@ -181,185 +169,3 @@ def call_home(*args, **kwds):
     kwds['sock'] = sock
     return connect_ssh(*args, **kwds)
 
-class Manager(object):
-
-    """
-    For details on the expected behavior of the operations and their
-        parameters refer to :rfc:`6241`.
-
-    Manager instances are also context managers so you can use it like this::
-
-        with manager.connect("host") as m:
-            # do your stuff
-
-    ... or like this::
-
-        m = manager.connect("host")
-        try:
-            # do your stuff
-        finally:
-            m.close_session()
-    """
-
-   # __metaclass__ = OpExecutor
-
-
-    HUGE_TREE_DEFAULT = False
-    """Default for `huge_tree` support for XML parsing of RPC replies (defaults to False)"""
-
-    def __init__(self, session, device_handler, timeout=30):
-        self._session = session
-        self._async_mode = False
-        self._timeout = timeout
-        self._raise_mode = operations.RaiseMode.ALL
-        self._huge_tree = self.HUGE_TREE_DEFAULT
-        self._device_handler = device_handler
-        self._vendor_operations = {}
-        if device_handler:
-            self._vendor_operations.update(device_handler.add_additional_operations())
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *args):
-        self.close_session()
-        return False
-
-    def __set_timeout(self, timeout):
-        self._timeout = timeout
-
-    def __set_async_mode(self, mode):
-        self._async_mode = mode
-
-    def __set_raise_mode(self, mode):
-        assert(mode in (operations.RaiseMode.NONE, operations.RaiseMode.ERRORS, operations.RaiseMode.ALL))
-        self._raise_mode = mode
-
-    def execute(self, cls, *args, **kwds):
-        return cls(self._session,
-                   device_handler=self._device_handler,
-                   async_mode=self._async_mode,
-                   timeout=self._timeout,
-                   raise_mode=self._raise_mode,
-                   huge_tree=self._huge_tree).request(*args, **kwds)
-
-    def locked(self, target):
-        """Returns a context manager for a lock on a datastore, where
-        *target* is the name of the configuration datastore to lock, e.g.::
-
-            with m.locked("running"):
-                # do your stuff
-
-        ... instead of::
-
-            m.lock("running")
-            try:
-                # do your stuff
-            finally:
-                m.unlock("running")
-        """
-        return operations.LockContext(self._session, self._device_handler, target)
-
-    def scp(self):
-        return self._session.scp()
-
-    def session(self):
-        raise NotImplementedError
-
-    def __getattr__(self, method):
-        if method in self._vendor_operations:
-            return functools.partial(self.execute, self._vendor_operations[method])
-        elif method in OPERATIONS:
-            return functools.partial(self.execute, OPERATIONS[method])
-        else:
-            """Parse args/kwargs correctly in order to build XML element"""
-            def _missing(*args, **kwargs):
-                m = method.replace('_', '-')
-                root = new_ele(m)
-                if args:
-                    for arg in args:
-                        sub_ele(root, arg)
-                r = self.rpc(root)
-                return r
-            return _missing
-
-    def rpc(self, *args, **kwds):
-        return operations.GenericRPC(self._session,
-                                     self._device_handler,
-                                     async_mode=self._async_mode,
-                                     timeout=self._timeout,
-                                     raise_mode=self._raise_mode,
-                                     huge_tree=self._huge_tree).request(*args, **kwds)
-
-    def take_notification(self, block=True, timeout=None):
-        """Attempt to retrieve one notification from the queue of received
-        notifications.
-
-        If block is True, the call will wait until a notification is
-        received.
-
-        If timeout is a number greater than 0, the call will wait that
-        many seconds to receive a notification before timing out.
-
-        If there is no notification available when block is False or
-        when the timeout has elapse, None will be returned.
-
-        Otherwise a :class:`~ncclient.operations.notify.Notification`
-        object will be returned.
-        """
-        return self._session.take_notification(block, timeout)
-
-    @property
-    def client_capabilities(self):
-        """:class:`~ncclient.capabilities.Capabilities` object representing
-        the client's capabilities."""
-        return self._session._client_capabilities
-
-    @property
-    def server_capabilities(self):
-        """:class:`~ncclient.capabilities.Capabilities` object representing
-        the server's capabilities."""
-        return self._session._server_capabilities
-
-    @property
-    def channel_id(self):
-        return self._session._channel_id
-
-    @property
-    def channel_name(self):
-        return self._session._channel_name
-
-    @property
-    def session_id(self):
-        """`session-id` assigned by the NETCONF server."""
-        return self._session.id
-
-    @property
-    def connected(self):
-        """Whether currently connected to the NETCONF server."""
-        return self._session.connected
-
-    async_mode = property(fget=lambda self: self._async_mode,
-                          fset=__set_async_mode)
-    """Specify whether operations are executed asynchronously (`True`) or
-    synchronously (`False`) (the default)."""
-
-    timeout = property(fget=lambda self: self._timeout, fset=__set_timeout)
-    """Specify the timeout for synchronous RPC requests."""
-
-    raise_mode = property(fget=lambda self: self._raise_mode,
-                          fset=__set_raise_mode)
-    """Specify which errors are raised as :exc:`~ncclient.operations.RPCError`
-    exceptions. Valid values are the constants defined in
-    :class:`~ncclient.operations.RaiseMode`.
-    The default value is :attr:`~ncclient.operations.RaiseMode.ALL`."""
-
-    @property
-    def huge_tree(self):
-        """Whether `huge_tree` support for XML parsing of RPC replies is enabled (default=False)
-        The default value is configurable through :attr:`~ncclient.manager.Manager.HUGE_TREE_DEFAULT`"""
-        return self._huge_tree
-
-    @huge_tree.setter
-    def huge_tree(self, x):
-        self._huge_tree = x

--- a/ncclient/operations/session.py
+++ b/ncclient/operations/session.py
@@ -15,7 +15,7 @@
 "Session-related NETCONF operations"
 
 from ncclient.xml_ import *
-
+from ncclient.transport.errors import SessionCloseError
 from ncclient.operations.rpc import RPC
 
 class CloseSession(RPC):
@@ -28,6 +28,13 @@ class CloseSession(RPC):
         self.session.close()
         return ret
 
+    def deliver_error(self, err):
+        # Since we've explicitly closed the session, the SessionCloseError is expected
+        # and should not actually be re-raised in the client context.
+        if not isinstance(err, SessionCloseError):
+            self.error = err
+
+        self.event.set()
 
 class KillSession(RPC):
 

--- a/ncclient/sync_manager.py
+++ b/ncclient/sync_manager.py
@@ -1,0 +1,227 @@
+import logging
+import functools
+from ncclient import operations
+from ncclient.xml_ import *
+
+logger = logging.getLogger('ncclient.manager')
+
+OPERATIONS = {
+    "get": operations.Get,
+    "get_config": operations.GetConfig,
+    "get_schema": operations.GetSchema,
+    "dispatch": operations.Dispatch,
+    "edit_config": operations.EditConfig,
+    "copy_config": operations.CopyConfig,
+    "validate": operations.Validate,
+    "commit": operations.Commit,
+    "discard_changes": operations.DiscardChanges,
+    "cancel_commit": operations.CancelCommit,
+    "delete_config": operations.DeleteConfig,
+    "lock": operations.Lock,
+    "unlock": operations.Unlock,
+    "create_subscription": operations.CreateSubscription,
+    "close_session": operations.CloseSession,
+    "kill_session": operations.KillSession,
+    "poweroff_machine": operations.PoweroffMachine,
+    "reboot_machine": operations.RebootMachine,
+}
+
+"""
+Dictionary of base method names and corresponding :class:`~ncclient.operations.RPC`
+subclasses. It is used to lookup operations, e.g. `get_config` is mapped to
+:class:`~ncclient.operations.GetConfig`. It is thus possible to add additional
+operations to the :class:`Manager` API.
+"""
+
+class Manager(object):
+
+    """
+    For details on the expected behavior of the operations and their
+        parameters refer to :rfc:`6241`.
+
+    Manager instances are also context managers so you can use it like this::
+
+        with manager.connect("host") as m:
+            # do your stuff
+
+    ... or like this::
+
+        m = manager.connect("host")
+        try:
+            # do your stuff
+        finally:
+            m.close_session()
+    """
+
+   # __metaclass__ = OpExecutor
+
+
+    HUGE_TREE_DEFAULT = False
+    """Default for `huge_tree` support for XML parsing of RPC replies (defaults to False)"""
+
+    def __init__(self, session, device_handler, timeout=30):
+        self._session = session
+        self._async_mode = False
+        self._timeout = timeout
+        self._raise_mode = operations.RaiseMode.ALL
+        self._huge_tree = self.HUGE_TREE_DEFAULT
+        self._device_handler = device_handler
+        self._vendor_operations = {}
+        if device_handler:
+            self._vendor_operations.update(device_handler.add_additional_operations())
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close_session()
+        return False
+
+    def __set_timeout(self, timeout):
+        self._timeout = timeout
+
+    def __set_async_mode(self, mode):
+        self._async_mode = mode
+
+    def __set_raise_mode(self, mode):
+        assert(mode in (operations.RaiseMode.NONE, operations.RaiseMode.ERRORS, operations.RaiseMode.ALL))
+        self._raise_mode = mode
+
+    def execute(self, cls, *args, **kwds):
+        return cls(self._session,
+                   device_handler=self._device_handler,
+                   async_mode=self._async_mode,
+                   timeout=self._timeout,
+                   raise_mode=self._raise_mode,
+                   huge_tree=self._huge_tree).request(*args, **kwds)
+
+    def locked(self, target):
+        """Returns a context manager for a lock on a datastore, where
+        *target* is the name of the configuration datastore to lock, e.g.::
+
+            with m.locked("running"):
+                # do your stuff
+
+        ... instead of::
+
+            m.lock("running")
+            try:
+                # do your stuff
+            finally:
+                m.unlock("running")
+        """
+        return operations.LockContext(self._session, self._device_handler, target)
+
+    def scp(self):
+        return self._session.scp()
+
+    def session(self):
+        raise NotImplementedError
+
+    def __getattr__(self, method):
+        if method in self._vendor_operations:
+            return functools.partial(self.execute, self._vendor_operations[method])
+        elif method in OPERATIONS:
+            return functools.partial(self.execute, OPERATIONS[method])
+        else:
+            """Parse args/kwargs correctly in order to build XML element"""
+            def _missing(*args, **kwargs):
+                m = method.replace('_', '-')
+                root = new_ele(m)
+                if args:
+                    for arg in args:
+                        sub_ele(root, arg)
+                r = self.rpc(root)
+                return r
+            return _missing
+
+    def rpc(self, *args, **kwds):
+        return operations.GenericRPC(self._session,
+                                     self._device_handler,
+                                     async_mode=self._async_mode,
+                                     timeout=self._timeout,
+                                     raise_mode=self._raise_mode,
+                                     huge_tree=self._huge_tree).request(*args, **kwds)
+
+    def take_notification(self, block=True, timeout=None):
+        """Attempt to retrieve one notification from the queue of received
+        notifications.
+
+        If block is True, the call will wait until a notification is
+        received.
+
+        If timeout is a number greater than 0, the call will wait that
+        many seconds to receive a notification before timing out.
+
+        If there is no notification available when block is False or
+        when the timeout has elapse, None will be returned.
+
+        Otherwise a :class:`~ncclient.operations.notify.Notification`
+        object will be returned.
+        """
+        return self._session.take_notification(block, timeout)
+
+    @property
+    def client_capabilities(self):
+        """:class:`~ncclient.capabilities.Capabilities` object representing
+        the client's capabilities."""
+        return self._session._client_capabilities
+
+    @property
+    def server_capabilities(self):
+        """:class:`~ncclient.capabilities.Capabilities` object representing
+        the server's capabilities."""
+        return self._session._server_capabilities
+
+    @property
+    def channel_id(self):
+        return self._session._channel_id
+
+    @property
+    def channel_name(self):
+        return self._session._channel_name
+
+    @property
+    def session_id(self):
+        """`session-id` assigned by the NETCONF server."""
+        return self._session.id
+
+    @property
+    def connected(self):
+        """Whether currently connected to the NETCONF server."""
+        return self._session.connected
+
+    async_mode = property(fget=lambda self: self._async_mode,
+                          fset=__set_async_mode)
+    """Specify whether operations are executed asynchronously (`True`) or
+    synchronously (`False`) (the default)."""
+
+    timeout = property(fget=lambda self: self._timeout, fset=__set_timeout)
+    """Specify the timeout for synchronous RPC requests."""
+
+    raise_mode = property(fget=lambda self: self._raise_mode,
+                          fset=__set_raise_mode)
+    """Specify which errors are raised as :exc:`~ncclient.operations.RPCError`
+    exceptions. Valid values are the constants defined in
+    :class:`~ncclient.operations.RaiseMode`.
+    The default value is :attr:`~ncclient.operations.RaiseMode.ALL`."""
+
+    @property
+    def huge_tree(self):
+        """Whether `huge_tree` support for XML parsing of RPC replies is enabled (default=False)
+        The default value is configurable through :attr:`~ncclient.manager.Manager.HUGE_TREE_DEFAULT`"""
+        return self._huge_tree
+
+    @huge_tree.setter
+    def huge_tree(self, x):
+        self._huge_tree = x
+
+    @property
+    def session(self):
+        "The `~ncclient.transport.Session` object associated with this RPC."
+        return self._session
+
+    @property
+    def device_handler(self):
+        return self._device_handler
+

--- a/test/asyncio_example.py
+++ b/test/asyncio_example.py
@@ -1,0 +1,70 @@
+import unittest
+import sys
+import asyncio
+from mock import patch, MagicMock
+from ncclient import operations
+from ncclient import manager
+from ncclient import async_manager
+
+class TestAsyncioManager(object):
+
+    def _mock_manager(self, async_mode=False):
+        conn = manager.connect(host='hostname',
+                               port=22,
+                               username='user',
+                               password='password',
+                               timeout=30,
+                               hostkey_verify=False,
+                               allow_agent=False,
+                               device_params={'name': 'junos'},
+                               async_mode=async_mode,
+                               raise_mode=operations.RaiseMode.ALL,
+                               huge_tree=True,
+                               )
+        return conn
+
+    @unittest.skipIf(sys.version_info.major == 2, "test not supported < python3")
+    @patch('ncclient.transport.SSHSession')
+    def test_async_mode(self, mock_ssh):
+        m = MagicMock()
+        mock_ssh.return_value = m
+        conn = self._mock_manager(async_mode=True)
+        loop = asyncio.get_event_loop()
+        return loop.run_until_complete(self.multi_operations(loop, conn))
+
+    async def multi_operations(self, loop, conn):
+        # `conn.get()` is equivalent to self.mock_get_operation(), and so on.
+        req = [
+               self.mock_get_operation(),
+               self.mock_get_config_operation(),
+               self.mock_edit_config_operation(),
+               self.mock_lock_operation(),
+               self.mock_duplicate_lock_operation(),
+              ]
+        tasks = [loop.create_task(r) for r in req]
+        return await asyncio.gather(*tasks)
+
+    async def mock_get_operation(self):
+        # mock the `get` operation
+        await asyncio.sleep(1)
+        return '<rpc-reply><data><root>This is `get` operations</root></data></rpc-reply>'
+
+    async def mock_get_config_operation(self):
+        # mock the `get-config` operation
+        await asyncio.sleep(1)
+        return '<rpc-reply><data><root>This is `get-config` operations</root></data></rpc-reply>'
+
+    async def mock_edit_config_operation(self):
+        # mock the `edit-config` operation
+        await asyncio.sleep(1)
+        return '<rpc-reply><ok/></rpc-reply>'
+
+    async def mock_lock_operation(self):
+        # mock the `lock` operation
+        await asyncio.sleep(1)
+        return '<rpc-reply><ok/></rpc-reply>'
+
+    async def mock_duplicate_lock_operation(self):
+        # mock the `lock` operation again
+        await asyncio.sleep(1)
+        return '<rpc-reply><rpc-error><error-message>Request resource already locked</error-message></rpc-error></rpc-reply>'

--- a/test/unit/test_manager.py
+++ b/test/unit/test_manager.py
@@ -3,7 +3,10 @@ from mock import patch, MagicMock
 from ncclient import manager
 from ncclient.devices.junos import JunosDeviceHandler
 import logging
+import sys
 
+if sys.version_info.major > 2:
+    from test.asyncio_example import *
 
 class TestManager(unittest.TestCase):
 
@@ -20,6 +23,23 @@ class TestManager(unittest.TestCase):
                                           timeout=3)
         self.assertEqual(conn._session, m)
         self.assertEqual(conn._timeout, 10)
+
+    @unittest.skipIf(sys.version_info.major == 2, "test not supported < python3")
+    @patch('ncclient.manager.connect_ssh')
+    def test_async_connect(self, mock_ssh):
+        expected = [
+            '<rpc-reply><data><root>This is `get` operations</root></data></rpc-reply>',
+            '<rpc-reply><data><root>This is `get-config` operations</root></data></rpc-reply>',
+            '<rpc-reply><ok/></rpc-reply>',
+            '<rpc-reply><ok/></rpc-reply>',
+            '<rpc-reply><rpc-error><error-message>Request resource already locked</error-message></rpc-error></rpc-reply>'
+           ]
+
+        obj = TestAsyncioManager()
+        res = obj.test_async_mode()
+
+        for i in range(len(expected)):
+            assert res[i] == expected[i]
 
     @patch('ncclient.manager.connect_ssh')
     def test_connect_ssh(self, mock_ssh):
@@ -108,7 +128,7 @@ class TestManager(unittest.TestCase):
         manager.connect(host='localhost', device_params={'name': 'junos', 
                                                         'local': True})
         mock_ssh.assert_called_once_with(host='localhost', 
-                            device_params={'local': True, 'name': 'junos'})
+                                         device_params={'local': True, 'name': 'junos'})
 
     @patch('paramiko.proxy.ProxyCommand')
     @patch('paramiko.Transport')
@@ -119,12 +139,12 @@ class TestManager(unittest.TestCase):
         ssh_config_path = 'test/unit/ssh_config'
 
         conn = manager.connect(host='fake_host',
-                                    port=830,
-                                    username='user',
-                                    password='password',
-                                    hostkey_verify=False,
-                                    allow_agent=False,
-                                    ssh_config=ssh_config_path)
+                               port=830,
+                               username='user',
+                               password='password',
+                               hostkey_verify=False,
+                               allow_agent=False,
+                               ssh_config=ssh_config_path)
 
         log.debug(mock_proxy.call_args[0][0])
         self.assertEqual(mock_proxy.called, 1)
@@ -147,13 +167,12 @@ class TestManager(unittest.TestCase):
     @patch('ncclient.transport.third_party.junos.ioproc.IOProc.connect')
     def test_ioproc(self, mock_connect, mock_ioproc):
         conn = manager.connect(host='localhost',
-                                    port=22,
-                                    username='user',
-                                    password='password',
-                                    timeout=3,
-                                    hostkey_verify=False,
-                                    device_params={'local': True, 'name': 'junos'},
-                                    manager_params={'timeout': 10})
+                               port=22,
+                               username='user',
+                               password='password',
+                               hostkey_verify=False,
+                               device_params={'local': True, 'name': 'junos'},
+                               manager_params={'timeout': 10})
         self.assertEqual(mock_connect.called, 1)
         self.assertEqual(conn._timeout, 10)
         self.assertEqual(conn._device_handler.device_params, {'local': True, 'name': 'junos'}) 
@@ -263,13 +282,13 @@ class TestManager(unittest.TestCase):
 
     def _mock_manager(self):
         conn = manager.connect(host='10.10.10.10',
-                                    port=22,
-                                    username='user',
-                                    password='password',
-                                    timeout=3,
-                                    hostkey_verify=False, allow_agent=False,
-                                    device_params={'name': 'junos'},
-                                    manager_params={'timeout': 10})
+                               port=22,
+                               username='user',
+                               password='password',
+                               timeout=3,
+                               hostkey_verify=False, allow_agent=False,
+                               device_params={'name': 'junos'},
+                               manager_params={'timeout': 10})
         return conn
 
     @patch('socket.fromfd')
@@ -283,11 +302,11 @@ class TestManager(unittest.TestCase):
 
     def _mock_outbound_manager(self):
         conn = manager.connect(host=None,
-                                    sock_fd=6,
-                                    username='user',
-                                    password='password',
-                                    device_params={'name': 'junos'},
-                                    hostkey_verify=False, allow_agent=False)
+                               sock_fd=6,
+                               username='user',
+                               password='password',
+                               device_params={'name': 'junos'},
+                               hostkey_verify=False, allow_agent=False)
         return conn
     
     @patch('socket.socket')


### PR DESCRIPTION
@einarnn Hi ,
This PR implements asyncio interface based on PR #76, please review it. :-)

The following is my solution:
1. the connect interface is normalized so that a sync_connect or async_connect can be selected based on async_mode in `manager.py`
2. move the class Manager from `manager.py` to `sync_manager.py`
3. add an `async_manager.py` that contains class AsyncioManager and asyncio_connect function
4. add an example to show how to use async_mode
5. add a testcase to `test_manager.py`, and skip asyncio in python2
