### PR TITLE
Bugfix some unreasonable places in Dispatch

### DIFF
--- a/ncclient/manager.py
+++ b/ncclient/manager.py
@@ -270,6 +270,14 @@ class Manager(object):
                 return r
             return _missing
 
+    def rpc(self, *args, **kwds):
+        return operations.GenericRPC(self._session,
+                                     self._device_handler,
+                                     async_mode=self._async_mode,
+                                     timeout=self._timeout,
+                                     raise_mode=self._raise_mode,
+                                     huge_tree=self._huge_tree).request(*args, **kwds)
+
     def take_notification(self, block=True, timeout=None):
         """Attempt to retrieve one notification from the queue of received
         notifications.

--- a/ncclient/operations/__init__.py
+++ b/ncclient/operations/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from ncclient.operations.errors import OperationError, TimeoutExpiredError, MissingCapabilityError
-from ncclient.operations.rpc import RPC, RPCReply, RPCError, RaiseMode
+from ncclient.operations.rpc import RPC, RPCReply, RPCError, RaiseMode, GenericRPC
 
 # rfc4741 ops
 
@@ -31,6 +31,7 @@ __all__ = [
     'RPCReply',
     'RPCError',
     'RaiseMode',
+    'GenericRPC',
     'Get',
     'GetConfig',
     'GetSchema',

--- a/ncclient/operations/retrieve.py
+++ b/ncclient/operations/retrieve.py
@@ -201,8 +201,8 @@ class Dispatch(RPC):
 
     """Generic retrieving wrapper"""
 
-    REPLY_CLS = GetReply
-    """See :class:`GetReply`."""
+    REPLY_CLS = RPCReply
+    """See :class:`RPCReply`."""
 
     def request(self, rpc_command, source=None, filter=None):
         """

--- a/ncclient/operations/rpc.py
+++ b/ncclient/operations/rpc.py
@@ -18,7 +18,7 @@ from uuid import uuid4
 from ncclient.xml_ import *
 from ncclient.logging_ import SessionLoggerAdapter
 from ncclient.transport import SessionListener
-
+from ncclient.operations import util
 from ncclient.operations.errors import OperationError, TimeoutExpiredError, MissingCapabilityError
 
 import logging
@@ -452,3 +452,48 @@ class RPC(object):
     @huge_tree.setter
     def huge_tree(self, x):
         self._huge_tree = x
+
+class GenericRPC(RPC):
+    """Generic rpc commands wrapper"""
+    REPLY_CLS = RPCReply
+    """See :class:`RPCReply`."""
+
+    def request(self, rpc_command, source=None, filter=None, config=None, target=None, format=None):
+        """
+        *rpc_command* specifies rpc command to be dispatched either in plain text or in xml element format (depending on command)
+
+        *target* name of the configuration datastore being edited
+
+        *source* name of the configuration datastore being queried
+
+        *config* is the configuration, which must be rooted in the `config` element. It can be specified either as a string or an :class:`~xml.etree.ElementTree.Element`.
+
+        *filter* specifies the portion of the configuration to retrieve (by default entire configuration is retrieved)
+
+        :seealso: :ref:`filter_params`
+
+        Examples of usage::
+
+            m.rpc('rpc_command')
+
+        or dispatch element like ::
+
+            rpc_command = new_ele('get-xnm-information')
+            sub_ele(rpc_command, 'type').text = "xml-schema"
+            m.rpc(rpc_command)
+        """
+
+        if etree.iselement(rpc_command):
+            node = rpc_command
+        else:
+            node = new_ele(rpc_command)
+        if target is not None:
+            node.append(util.datastore_or_url("target", target, self._assert))
+        if source is not None:
+            node.append(util.datastore_or_url("source", source, self._assert))
+        if filter is not None:
+            node.append(util.build_filter(filter))
+        if config is not None:
+            node.append(validated_element(config, ("config", qualify("config"))))
+
+        return self._request(node)

--- a/test/unit/test_manager.py
+++ b/test/unit/test_manager.py
@@ -67,9 +67,9 @@ class TestManager(unittest.TestCase):
                                          allow_agent=False)
 
     @patch('ncclient.transport.SSHSession.connect')
-    @patch('ncclient.operations.third_party.juniper.rpc.GetConfiguration._request')
-    @patch('ncclient.operations.third_party.juniper.rpc.ExecuteRpc._request')
-    def test_manager_getattr2(self, mock_rpc, mock_request, mock_ssh):
+    @patch('ncclient.transport.Session.send')
+    @patch('ncclient.operations.rpc.RPC._request')
+    def test_manager_getattr2(self, mock_request, mock_send, mock_ssh):
         conn = self._mock_manager()
         conn.get_edit('config')
         mock_ssh.assert_called_once_with(host='10.10.10.10',


### PR DESCRIPTION
@einarnn Hi,
I found some unreasonable places in Dispatch as follows.
1. Dispatch RPC uses `GetReply` for its reply class, as you mentioned at #252.
2. It doesn't support the operations w/ `config` or `target` parameter, such as `edit-config`, `copy-config` and so on.

This PR fixes them. :-)