### PR TITLE
add support for call home feature

### DIFF
--- a/ncclient/manager.py
+++ b/ncclient/manager.py
@@ -20,6 +20,7 @@ It exposes all core functionality.
 
 from ncclient import operations
 from ncclient import transport
+import socket
 import logging
 import functools
 
@@ -167,6 +168,18 @@ def connect(*args, **kwds):
         else:
             return connect_ssh(*args, **kwds)
 
+def call_home(*args, **kwds):
+    host = kwds["host"]
+    port = kwds.get("port",4334)
+    srv_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    srv_socket.bind((host, port))
+    srv_socket.settimeout(10)
+    srv_socket.listen()
+    
+    sock, remote_host = srv_socket.accept()
+    logger.info('Callhome connection initiated from remote host {0}'.format(remote_host))
+    kwds['sock'] = sock
+    return connect_ssh(*args, **kwds)
 
 class Manager(object):
 

--- a/ncclient/transport/ssh.py
+++ b/ncclient/transport/ssh.py
@@ -183,7 +183,8 @@ class SSHSession(Session):
             look_for_keys       = True,
             ssh_config          = None,
             sock_fd             = None,
-            bind_addr           = None):
+            bind_addr           = None,
+            sock                = None):
 
         """Connect via SSH and initialize the NETCONF session. First attempts the publickey authentication method and then password authentication.
 
@@ -216,9 +217,11 @@ class SSHSession(Session):
         *sock_fd* is an already open socket which shall be used for this connection. Useful for NETCONF outbound ssh. Use host=None together with a valid sock_fd number
 
         *bind_addr* is a (local) source IP address to use, must be reachable from the remote device.
+        
+        *sock* is an already open Python socket to be used for this connection.
         """
-        if not (host or sock_fd):
-            raise SSHError("Missing host or socket fd")
+        if not (host or sock_fd or sock):
+            raise SSHError("Missing host, socket or socket fd")
 
         self._host = host
 
@@ -262,7 +265,7 @@ class SSHSession(Session):
         if username is None:
             username = getpass.getuser()
 
-        if sock_fd is None:
+        if sock_fd is None and sock is None:
             proxycommand = config.get("proxycommand")
             if proxycommand:
                 self.logger.debug("Configuring Proxy. %s", proxycommand)
@@ -289,7 +292,7 @@ class SSHSession(Session):
                     break
                 else:
                     raise SSHError("Could not open socket to %s:%s" % (host, port))
-        else:
+        elif sock is None:
             if sys.version_info[0] < 3:
                 s = socket.fromfd(int(sock_fd), socket.AF_INET, socket.SOCK_STREAM)
                 sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM, _sock=s)

--- a/test/unit/test_manager.py
+++ b/test/unit/test_manager.py
@@ -289,6 +289,20 @@ class TestManager(unittest.TestCase):
                                     device_params={'name': 'junos'},
                                     hostkey_verify=False, allow_agent=False)
         return conn
+    
+    @patch('socket.socket')
+    @patch('ncclient.manager.connect_ssh')
+    def test_call_home(self, mock_ssh, mock_socket_open):
+        mock_connected_socket = MagicMock()
+        mock_server_socket = MagicMock()
+        mock_socket_open.return_value = mock_server_socket
+        mock_server_socket.accept.return_value = (mock_connected_socket,
+                                                  'remote.host')
+
+        with manager.call_home(host='0.0.0.0', port=1234) as chm:
+            mock_ssh.assert_called_once_with(host='0.0.0.0',
+                                                port=1234,
+                                                sock=mock_connected_socket)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
code like:
#!/usr/bin/env python
from ncclient import manager

if __name__ == '__main__':
    with manager.call_home(host='', port=4334, username='netconf', password='netconf', hostkey_verify=False) as m:
        c = m.get_config(source='running').data_xml