### PR TITLE
Add missing requirements to fix broken RTD builds

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
 Sphinx==3.2.0
+-r ../requirements.txt
 


### PR DESCRIPTION
The documentation over at https://ncclient.readthedocs.io/en/latest/ is missing a lot of information. Mostly this seems to be caused by lxml not being installed in the RTD build process causing a lot of errors

```
WARNING: autodoc: failed to import class 'operations.RPC' from module 'ncclient'; the following exception was raised:
No module named 'lxml'
WARNING: autodoc: failed to import class 'operations.RPCReply' from module 'ncclient'; the following exception was raised:
No module named 'lxml'
WARNING: autodoc: failed to import exception 'operations.RPCError' from module 'ncclient'; the following exception was raised:
No module named 'lxml'
WARNING: autodoc: failed to import class 'operations.Get' from module 'ncclient'; the following exception was raised:
No module named 'lxml'
WARNING: autodoc: failed to import class 'operations.GetConfig' from module 'ncclient'; the following exception was raised:
No module named 'lxml'
WARNING: autodoc: failed to import class 'operations.GetReply' from module 'ncclient'; the following exception was raised:
No module named 'lxml'
```
(from https://readthedocs.org/projects/ncclient/builds/11623595/)

This PR adds the main ncclient requirements to the RTD build.

While building locally there's also a warning about:

docs/source/extending.rst: WARNING: document isn't included in any toctree

I didn't touch that file but as it's basically empty and hasn't been touched in years I guess it's ok to just remove it.
