### PR TITLE
Bugfix url option is missing for edit-config

### DIFF
--- a/ncclient/operations/edit.py
+++ b/ncclient/operations/edit.py
@@ -63,9 +63,15 @@ class EditConfig(RPC):
             sub_ele(node, "error-option").text = error_option
         if format == 'xml':
             node.append(validated_element(config, ("config", qualify("config"))))
-        if format == 'text':
+        elif format == 'text':
             config_text = sub_ele(node, "config-text")
             sub_ele(config_text, "configuration-text").text = config
+        elif format == 'url':
+            if util.url_validator(config):
+                self._assert(':url')
+                sub_ele(node, "url").text = config
+            else:
+                raise OperationError("Invalid URL.")
         return self._request(node)
 
 

--- a/ncclient/operations/util.py
+++ b/ncclient/operations/util.py
@@ -15,8 +15,8 @@
 'Boilerplate ugliness'
 
 from ncclient.xml_ import *
-
 from ncclient.operations.errors import OperationError, MissingCapabilityError
+from urllib.parse import urlparse
 
 def one_of(*args):
     "Verifies that only one of the arguments is not None"
@@ -83,3 +83,10 @@ def validate_args(arg_name, value, args_list):
     if value not in args_list:
         raise OperationError('Invalid value "%s" in "%s" element' % (value, arg_name))
     return True
+
+def url_validator(url):
+    try:
+        result = urlparse(url)
+        return all([result.scheme, result.netloc])
+    except:
+        return False

--- a/ncclient/operations/util.py
+++ b/ncclient/operations/util.py
@@ -16,7 +16,10 @@
 
 from ncclient.xml_ import *
 from ncclient.operations.errors import OperationError, MissingCapabilityError
-from urllib.parse import urlparse
+try:
+    from urlparse import urlparse
+except:
+    from urllib.parse import urlparse
 
 def one_of(*args):
     "Verifies that only one of the arguments is not None"

--- a/test/unit/operations/test_edit.py
+++ b/test/unit/operations/test_edit.py
@@ -70,6 +70,37 @@ class TestEdit(unittest.TestCase):
         call = ElementTree.tostring(call)
         self.assertEqual(call, xml)
 
+    @patch('ncclient.operations.edit.RPC._request')
+    @patch('ncclient.operations.edit.RPC._assert')
+    def test_edit_config_valid_url(self, mock_assert, mock_request):
+        session = ncclient.transport.SSHSession(self.device_handler)
+        obj = EditConfig(
+            session,
+            self.device_handler,
+            raise_mode=RaiseMode.ALL)
+        config = "https://www.xxx.org/index.html"
+        obj.request(config, format='url')
+        node = new_ele("edit-config")
+        node.append(util.datastore_or_url("target", "candidate"))
+        sub_ele(node, "url").text = config
+
+        xml = ElementTree.tostring(node)
+        call = mock_request.call_args_list[0][0][0]
+        call = ElementTree.tostring(call)
+        self.assertEqual(call, xml)
+
+    @patch('ncclient.operations.edit.RPC._request')
+    @patch('ncclient.operations.edit.RPC._assert')
+    def test_edit_config_invalid_url(self, mock_assert, mock_request):
+        session = ncclient.transport.SSHSession(self.device_handler)
+        obj = EditConfig(
+            session,
+            self.device_handler,
+            raise_mode=RaiseMode.ALL)
+        config = "Invalid URL"
+        self.assertRaises(OperationError, obj.request,
+                          config, format='url')
+
     def test_edit_config_invalid_arguments_exception(self):
         session = ncclient.transport.SSHSession(self.device_handler)
         session._server_capabilities = [":rollback-on-error", ":validate", ":validate:1.1"]


### PR DESCRIPTION
Hi, 
This PR adds a `url` option to `edit-config`, as mentioned at #431. :-)