### PR TITLE
Refactor the close-session request in order to avoid deadloop

### DIFF
--- a/ncclient/operations/session.py
+++ b/ncclient/operations/session.py
@@ -24,10 +24,9 @@ class CloseSession(RPC):
 
     def request(self):
         "Request graceful termination of the NETCONF session, and also close the transport."
-        try:
-            return self._request(new_ele("close-session"))
-        finally:
-            self.session.close()
+        ret = self._request(new_ele("close-session"))
+        self.session.close()
+        return ret
 
 
 class KillSession(RPC):


### PR DESCRIPTION
I deeply studied the infinite loop problem and found that it might be caused by the `close-session` operation.

1.  the first example:
```
conn = manager.connect(...)
a = conn.close_session()
print(a)
```
the result:
```
<rpc-reply xmlns=“xxx”, message-id="xxx"><ok/></rpc-reply>
```
2. the second example like https://github.com/ncclient/ncclient/issues/394#issuecomment-639332018
```
#!/usr/bin/env python3
import threading
from ncclient import manager

class test(object):
    def __init__(self):
        self.client = manager.connect(
            host="xxx",
            port=xxx,,
            username="admin",
            password="admin",
            hostkey_verify=False,
            look_for_keys=False,
            allow_agent=False,
        )
        raise Exception()

    def __del__(self):
        print(threading.current_thread())
        print(threading.currentThread())
        print("close",flush=True)
        self.client.close_session()


test()
```
the result is that the program is stuck in a infinite loop.

The previous logic is that:
1. it sends a `close-session` operation after throwing an Exception.
2. the client has been waiting for the server's response until it times out.
3. finally, it calls `self.session.close()` to close session, which results in an infinite loop.

But now,
1. it sends a `close-session` operation after throwing an Exception.
2. the client has been waiting for the server's response, if it times out , raise a timeout exception, otherwise, it call `self.session.close()` to close session.
