### PR TITLE
Fixed support for 1.1 chunking with multibyte characters

### DIFF
--- a/ncclient/transport/__init__.py
+++ b/ncclient/transport/__init__.py
@@ -14,7 +14,7 @@
 
 "Transport layer"
 
-from ncclient.transport.session import Session, SessionListener
+from ncclient.transport.session import Session, SessionListener, NetconfBase
 from ncclient.transport.ssh import SSHSession
 from ncclient.transport.errors import *
 
@@ -25,6 +25,7 @@ __all__ = [
     'TransportError',
     'AuthenticationError',
     'SessionCloseError',
+    'NetconfBase',
     'SSHError',
     'SSHUnknownHostError'
 

--- a/ncclient/transport/ssh.py
+++ b/ncclient/transport/ssh.py
@@ -46,9 +46,9 @@ PORT_NETCONF_DEFAULT = 830
 
 BUF_SIZE = 4096
 # v1.0: RFC 4742
-MSG_DELIM = "]]>]]>"
+MSG_DELIM = b"]]>]]>"
 # v1.1: RFC 6242
-END_DELIM = '\n##\n'
+END_DELIM = b'\n##\n'
 
 TICK = 0.1
 
@@ -84,13 +84,6 @@ def _colonify(fp):
         finga += ":" + fp[idx:idx+2]
     return finga
 
-
-if sys.version < '3':
-    def textify(buf):
-        return buf
-else:
-    def textify(buf):
-        return buf.decode('UTF-8')
 
 if sys.version < '3':
     from six import StringIO
@@ -469,7 +462,7 @@ class SSHSession(Session):
         chan = self._channel
         q = self._q
 
-        def start_delim(data_len): return '\n#%s\n' % (data_len)
+        def start_delim(data_len): return b'\n#%i\n' % (data_len)
 
         try:
             s = selectors.DefaultSelector()
@@ -498,11 +491,11 @@ class SSHSession(Session):
                         raise SessionCloseError(self._buffer.getvalue())
                 if not q.empty() and chan.send_ready():
                     self.logger.debug("Sending message")
-                    data = q.get()
+                    data = q.get().encode()
                     if self._base == NetconfBase.BASE_11:
-                        data = "%s%s%s" % (start_delim(len(data)), data, END_DELIM)
+                        data = b"%s%s%s" % (start_delim(len(data)), data, END_DELIM)
                     else:
-                        data = "%s%s" % (data, MSG_DELIM)
+                        data = b"%s%s" % (data, MSG_DELIM)
                     self.logger.info("Sending:\n%s", data)
                     while data:
                         n = chan.send(data)

--- a/test/unit/transport/test_ssh.py
+++ b/test/unit/transport/test_ssh.py
@@ -1,7 +1,8 @@
+# -*- coding: utf-8 -*-
 import unittest
 from mock import MagicMock, patch
 from ncclient.transport.ssh import SSHSession
-from ncclient.transport import AuthenticationError, SessionCloseError
+from ncclient.transport import AuthenticationError, SessionCloseError, NetconfBase
 import paramiko
 from ncclient.devices.junos import JunosDeviceHandler
 import sys
@@ -295,21 +296,36 @@ class TestSSH(unittest.TestCase):
                 SessionCloseError))
 
     @unittest.skipIf(sys.version_info.major == 2, "test not supported < Python3")
+    def test_run_send_py3_10(self):
+        self._test_run_send_py3(NetconfBase.BASE_10,
+                                lambda msg: msg.encode() + b"]]>]]>")
+
+    @unittest.skipIf(sys.version_info.major == 2, "test not supported < Python3")
+    def test_run_send_py3_11(self):
+        def chunker(msg):
+            encmsg = msg.encode()
+            chunks = b"\n#%i\n%b\n##\n" % (len(encmsg), encmsg)
+            return chunks
+        self._test_run_send_py3(NetconfBase.BASE_11, chunker)
+
     @patch('ncclient.transport.ssh.SSHSession.close')
     @patch('paramiko.channel.Channel.send_ready')
     @patch('paramiko.channel.Channel.send')
     @patch('selectors.DefaultSelector.select')
     @patch('ncclient.transport.ssh.Session._dispatch_error')
-    def test_run_send_py3(self, mock_error, mock_selector, mock_send, mock_ready, mock_close):
+    def _test_run_send_py3(self, base, chunker, mock_error, mock_selector,
+                           mock_send, mock_ready, mock_close):
         mock_selector.return_value = False
         mock_ready.return_value = True
         mock_send.return_value = -1
         device_handler = JunosDeviceHandler({'name': 'junos'})
         obj = SSHSession(device_handler)
         obj._channel = paramiko.Channel("c100")
-        obj._q.put("rpc")
+        msg = "naïve garçon"
+        obj._q.put(msg)
+        obj._base = base
         obj.run()
-        self.assertEqual(mock_send.call_args_list[0][0][0], "rpc]]>]]>")
+        self.assertEqual(mock_send.call_args_list[0][0][0], chunker(msg))
         self.assertTrue(
             isinstance(
                 mock_error.call_args_list[0][0][0],


### PR DESCRIPTION
The 1.1 chunking implementation is broken for multibyte characters - the implementation counts number of characters, but it should count number of bytes.