### PR TITLE
Remove shebang (#!) lines from non-script Python sources

### DIFF
--- a/ncclient/operations/third_party/h3c/__init__.py
+++ b/ncclient/operations/third_party/h3c/__init__.py
@@ -1,3 +1,2 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # by yangxufeng.zhao

--- a/ncclient/operations/third_party/h3c/rpc.py
+++ b/ncclient/operations/third_party/h3c/rpc.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # by yangxufeng.zhao
 

--- a/ncclient/operations/third_party/huawei/__init__.py
+++ b/ncclient/operations/third_party/huawei/__init__.py
@@ -1,3 +1,2 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # by yangxufeng.zhao

--- a/ncclient/operations/third_party/huawei/rpc.py
+++ b/ncclient/operations/third_party/huawei/rpc.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # by yangxufeng.zhao
 


### PR DESCRIPTION
Remove shebang (#!) lines from Python sources that are not intended to be executed as scripts.