### PR TITLE
fix junos ioproc connection in python3

### DIFF
--- a/ncclient/transport/third_party/junos/ioproc.py
+++ b/ncclient/transport/third_party/junos/ioproc.py
@@ -41,7 +41,7 @@ class IOProc(SSHSession):
 
     def connect(self):
         stdoutdata = check_output(NETCONF_SHELL, shell=True, stdin=PIPE,
-                                  stderr=STDOUT).decode("latin-1")
+                                  stderr=STDOUT).decode(encoding="utf8")
         if 'error: Restricted user session' in stdoutdata:
             obj = re.search(r'<error-message>\n?(.*)\n?</error-message>', stdoutdata, re.M)
             if obj:

--- a/ncclient/transport/third_party/junos/ioproc.py
+++ b/ncclient/transport/third_party/junos/ioproc.py
@@ -41,14 +41,14 @@ class IOProc(SSHSession):
 
     def connect(self):
         stdoutdata = check_output(NETCONF_SHELL, shell=True, stdin=PIPE,
-                                  stderr=STDOUT)
-        if six.b('error: Restricted user session') in stdoutdata:
+                                  stderr=STDOUT).decode("latin-1")
+        if 'error: Restricted user session' in stdoutdata:
             obj = re.search(r'<error-message>\n?(.*)\n?</error-message>', stdoutdata, re.M)
             if obj:
                 raise PermissionError(obj.group(1))
             else:
                 raise PermissionError('Restricted user session')
-        elif six.b('xml-mode: command not found') in stdoutdata:
+        elif 'xml-mode: command not found' in stdoutdata:
             raise PermissionError('xml-mode: command not found')
         self._channel = Popen([NETCONF_SHELL],
                               stdin=PIPE, stdout=PIPE, stderr=STDOUT)


### PR DESCRIPTION
subprocess.check_output() in python3 return bytes instead of string as in python2, so line 46 raise an exception "TypeError: cannot use a string pattern on a bytes-like object"

Decoding stdoutdata as "latin-1" prevents it. Also in this case six.b() does not need any more