### PR TITLE
Use unittest.mock from the Python 3 standard library instead of PyPI mock, when available

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,5 +2,5 @@ pytest-runner
 pytest-cov
 sphinx
 flake8
-mock; python_version < '3.4'
+mock; python_version < '3.6'
 nose

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,5 +2,5 @@ pytest-runner
 pytest-cov
 sphinx
 flake8
-mock
+mock; python_version < '3.4'
 nose

--- a/test/unit/devices/test_junos.py
+++ b/test/unit/devices/test_junos.py
@@ -1,7 +1,10 @@
 import unittest
 from ncclient.devices.junos import *
 import ncclient.transport
-from mock import patch
+try:
+    from unittest.mock import patch  # Python 3.4 and later
+except ImportError:
+    from mock import patch
 import paramiko
 import sys
 

--- a/test/unit/operations/test_edit.py
+++ b/test/unit/operations/test_edit.py
@@ -1,6 +1,9 @@
 from ncclient.operations.edit import *
 import unittest
-from mock import patch, MagicMock
+try:
+    from unittest.mock import patch, MagicMock  # Python 3.4 and later
+except ImportError:
+    from mock import patch, MagicMock
 from ncclient import manager
 import ncclient.manager
 import ncclient.transport

--- a/test/unit/operations/test_lock.py
+++ b/test/unit/operations/test_lock.py
@@ -1,6 +1,9 @@
 from ncclient.operations.lock import *
 import unittest
-from mock import patch
+try:
+    from unittest.mock import patch  # Python 3.4 and later
+except ImportError:
+    from mock import patch
 from ncclient import manager
 import ncclient.manager
 import ncclient.transport

--- a/test/unit/operations/test_retrieve.py
+++ b/test/unit/operations/test_retrieve.py
@@ -1,6 +1,9 @@
 from ncclient.operations.retrieve import *
 import unittest
-from mock import patch
+try:
+    from unittest.mock import patch  # Python 3.4 and later
+except ImportError:
+    from mock import patch
 from ncclient import manager
 import ncclient.manager
 import ncclient.transport

--- a/test/unit/operations/test_rpc.py
+++ b/test/unit/operations/test_rpc.py
@@ -1,6 +1,9 @@
 from ncclient.operations.rpc import *
 import unittest
-from mock import patch
+try:
+    from unittest.mock import patch  # Python 3.4 and later
+except ImportError:
+    from mock import patch
 from ncclient import manager
 import ncclient.manager
 import ncclient.transport

--- a/test/unit/operations/test_session.py
+++ b/test/unit/operations/test_session.py
@@ -1,6 +1,9 @@
 from ncclient.operations.session import *
 import unittest
-from mock import patch
+try:
+    from unittest.mock import patch  # Python 3.4 and later
+except ImportError:
+    from mock import patch
 from ncclient import manager
 import ncclient.manager
 import ncclient.transport

--- a/test/unit/operations/test_subscribe.py
+++ b/test/unit/operations/test_subscribe.py
@@ -1,7 +1,10 @@
 from ncclient.operations.edit import *
 from ncclient.operations.subscribe import *
 import unittest
-from mock import patch, MagicMock
+try:
+    from unittest.mock import patch, MagicMock  # Python 3.4 and later
+except ImportError:
+    from mock import patch, MagicMock
 from ncclient import manager
 import ncclient.manager
 import ncclient.transport

--- a/test/unit/operations/test_utils.py
+++ b/test/unit/operations/test_utils.py
@@ -1,7 +1,10 @@
 import unittest
 from xml.etree import ElementTree
 from ncclient.operations.util import *
-from mock import MagicMock
+try:
+    from unittest.mock import MagicMock  # Python 3.4 and later
+except ImportError:
+    from mock import MagicMock
 
 xml = """<filter type="xpath">
         <configuration>

--- a/test/unit/operations/third_party/alu/test_rpc.py
+++ b/test/unit/operations/third_party/alu/test_rpc.py
@@ -1,5 +1,8 @@
 import unittest
-from mock import patch
+try:
+    from unittest.mock import patch  # Python 3.4 and later
+except ImportError:
+    from mock import patch
 from ncclient import manager
 import ncclient.transport
 from ncclient.operations.third_party.alu.rpc import *

--- a/test/unit/operations/third_party/h3c/test_rpc.py
+++ b/test/unit/operations/third_party/h3c/test_rpc.py
@@ -1,5 +1,8 @@
 import unittest
-from mock import patch
+try:
+    from unittest.mock import patch  # Python 3.4 and later
+except ImportError:
+    from mock import patch
 from ncclient import manager
 import ncclient.transport
 from ncclient.operations.third_party.h3c.rpc import *

--- a/test/unit/operations/third_party/hpcomware/test_rpc.py
+++ b/test/unit/operations/third_party/hpcomware/test_rpc.py
@@ -1,5 +1,8 @@
 import unittest
-from mock import patch
+try:
+    from unittest.mock import patch  # Python 3.4 and later
+except ImportError:
+    from mock import patch
 from ncclient import manager
 import ncclient.transport
 from ncclient.operations.third_party.hpcomware.rpc import *

--- a/test/unit/operations/third_party/huawei/test_rpc.py
+++ b/test/unit/operations/third_party/huawei/test_rpc.py
@@ -1,5 +1,8 @@
 import unittest
-from mock import patch
+try:
+    from unittest.mock import patch  # Python 3.4 and later
+except ImportError:
+    from mock import patch
 from ncclient import manager
 import ncclient.transport
 from ncclient.operations.third_party.huawei.rpc import *

--- a/test/unit/operations/third_party/iosxe/test_rpc.py
+++ b/test/unit/operations/third_party/iosxe/test_rpc.py
@@ -1,5 +1,8 @@
 import unittest
-from mock import patch
+try:
+    from unittest.mock import patch  # Python 3.4 and later
+except ImportError:
+    from mock import patch
 from ncclient import manager
 import ncclient.transport
 from ncclient.operations.third_party.iosxe.rpc import *

--- a/test/unit/operations/third_party/juniper/test_rpc.py
+++ b/test/unit/operations/third_party/juniper/test_rpc.py
@@ -1,7 +1,10 @@
 from ncclient.operations.third_party.juniper.rpc import *
 import json
 import unittest
-from mock import patch
+try:
+    from unittest.mock import patch  # Python 3.4 and later
+except ImportError:
+    from mock import patch
 from ncclient import manager
 import ncclient.manager
 import ncclient.transport

--- a/test/unit/operations/third_party/nexus/test_rpc.py
+++ b/test/unit/operations/third_party/nexus/test_rpc.py
@@ -1,5 +1,8 @@
 import unittest
-from mock import patch
+try:
+    from unittest.mock import patch  # Python 3.4 and later
+except ImportError:
+    from mock import patch
 from ncclient import manager
 import ncclient.transport
 from ncclient.operations.third_party.nexus.rpc import *

--- a/test/unit/operations/third_party/sros/test_rpc.py
+++ b/test/unit/operations/third_party/sros/test_rpc.py
@@ -1,5 +1,8 @@
 import unittest
-from mock import patch
+try:
+    from unittest.mock import patch  # Python 3.4 and later
+except ImportError:
+    from mock import patch
 from ncclient import manager
 import ncclient.transport
 from ncclient.operations.third_party.sros.rpc import *

--- a/test/unit/test_manager.py
+++ b/test/unit/test_manager.py
@@ -1,5 +1,8 @@
 import unittest
-from mock import patch, MagicMock
+try:
+    from unittest.mock import patch, MagicMock  # Python 3.4 and later
+except ImportError:
+    from mock import patch, MagicMock
 from ncclient import manager
 from ncclient.devices.junos import JunosDeviceHandler
 import logging

--- a/test/unit/test_manager.py
+++ b/test/unit/test_manager.py
@@ -1,7 +1,8 @@
 import unittest
 try:
     from unittest.mock import patch, MagicMock  # Python 3.4 and later
-except ImportError:
+    getattr(MagicMock, 'assert_called_once')  # Python 3.6 and later
+except (ImportError, AttributeError):
     from mock import patch, MagicMock
 from ncclient import manager
 from ncclient.devices.junos import JunosDeviceHandler

--- a/test/unit/transport/test_parser.py
+++ b/test/unit/transport/test_parser.py
@@ -1,7 +1,10 @@
 import os
 
 import unittest
-from mock import patch
+try:
+    from unittest.mock import patch  # Python 3.4 and later
+except ImportError:
+    from mock import patch
 import paramiko
 
 from ncclient import manager

--- a/test/unit/transport/test_session.py
+++ b/test/unit/transport/test_session.py
@@ -1,5 +1,8 @@
 import unittest
-from mock import patch
+try:
+    from unittest.mock import patch  # Python 3.4 and later
+except ImportError:
+    from mock import patch
 from ncclient.transport.session import *
 from ncclient.devices.junos import JunosDeviceHandler
 try:

--- a/test/unit/transport/test_ssh.py
+++ b/test/unit/transport/test_ssh.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 import unittest
-from mock import MagicMock, patch
+try:
+    from unittest.mock import MagicMock, patch  # Python 3.4 and later
+except ImportError:
+    from mock import MagicMock, patch
 from ncclient.transport.ssh import SSHSession
 from ncclient.transport import AuthenticationError, SessionCloseError, NetconfBase
 import paramiko


### PR DESCRIPTION
See also https://fedoraproject.org/wiki/Changes/DeprecatePythonMock.