### PR TITLE
remove explicit rpc method and revert to getattr path

### DIFF
--- a/ncclient/manager.py
+++ b/ncclient/manager.py
@@ -47,6 +47,7 @@ OPERATIONS = {
     "kill_session": operations.KillSession,
     "poweroff_machine": operations.PoweroffMachine,
     "reboot_machine": operations.RebootMachine,
+    "rpc": operations.GenericRPC,
 }
 
 """
@@ -288,14 +289,6 @@ class Manager(object):
                 r = self.rpc(root)
                 return r
             return _missing
-
-    def rpc(self, *args, **kwds):
-        return operations.GenericRPC(self._session,
-                                     self._device_handler,
-                                     async_mode=self._async_mode,
-                                     timeout=self._timeout,
-                                     raise_mode=self._raise_mode,
-                                     huge_tree=self._huge_tree).request(*args, **kwds)
 
     def take_notification(self, block=True, timeout=None):
         """Attempt to retrieve one notification from the queue of received


### PR DESCRIPTION
Addressing #488 to revert unintentional change of behavior for RPC lookup.