### PR TITLE
Remove extraneous capability in default device

### DIFF
--- a/ncclient/devices/default.py
+++ b/ncclient/devices/default.py
@@ -52,7 +52,7 @@ class DefaultDeviceHandler(object):
             "urn:ietf:params:netconf:capability:url:1.0?scheme=http,ftp,file,https,sftp",
             "urn:ietf:params:netconf:capability:validate:1.0",
             "urn:ietf:params:netconf:capability:xpath:1.0",
-            "urn:ietf:params:netconf:capability:notification:1.0",,
+            "urn:ietf:params:netconf:capability:notification:1.0",
             "urn:ietf:params:netconf:capability:interleave:1.0",
             "urn:ietf:params:netconf:capability:with-defaults:1.0"
     ]

--- a/ncclient/devices/default.py
+++ b/ncclient/devices/default.py
@@ -52,8 +52,7 @@ class DefaultDeviceHandler(object):
             "urn:ietf:params:netconf:capability:url:1.0?scheme=http,ftp,file,https,sftp",
             "urn:ietf:params:netconf:capability:validate:1.0",
             "urn:ietf:params:netconf:capability:xpath:1.0",
-            "urn:ietf:params:netconf:capability:notification:1.0",
-            "urn:liberouter:params:netconf:capability:power-control:1.0",
+            "urn:ietf:params:netconf:capability:notification:1.0",,
             "urn:ietf:params:netconf:capability:interleave:1.0",
             "urn:ietf:params:netconf:capability:with-defaults:1.0"
     ]


### PR DESCRIPTION
urn:liberouter:params:netconf:capability:power-control:1.0 was included in commit https://github.com/ncclient/ncclient/commit/89adf69fde9f0da8a436424f1c774f496a204361