### PR TITLE
reading correct user known_hosts files

### DIFF
--- a/ncclient/manager.py
+++ b/ncclient/manager.py
@@ -106,15 +106,12 @@ def _extract_nc_params(kwds):
     return nc_params
 
 def connect_ssh(*args, **kwds):
-    """
-    Initialize a :class:`Manager` over the SSH transport.
+    """Initialize a :class:`Manager` over the SSH transport.
     For documentation of arguments see :meth:`ncclient.transport.SSHSession.connect`.
 
     The underlying :class:`ncclient.transport.SSHSession` is created with
-    :data:`CAPABILITIES`. It is first instructed to
-    :meth:`~ncclient.transport.SSHSession.load_known_hosts` and then
-    all the provided arguments are passed directly to its implementation
-    of :meth:`~ncclient.transport.SSHSession.connect`.
+    :data:`CAPABILITIES`. All the provided arguments are passed directly to its
+    implementation of :meth:`~ncclient.transport.SSHSession.connect`.
 
     To customize the :class:`Manager`, add a `manager_params` dictionary in connection
     parameters (e.g. `manager_params={'timeout': 60}` for a bigger RPC timeout parameter)
@@ -125,6 +122,7 @@ def connect_ssh(*args, **kwds):
 
     A custom device handler can be provided with
     `device_params={'handler':<handler class>}` in connection parameters.
+
     """
     # Extract device/manager/netconf parameter dictionaries, if they were passed into this function.
     # Remove them from kwds (which should keep only session.connect() parameters).
@@ -136,8 +134,6 @@ def connect_ssh(*args, **kwds):
     device_handler.add_additional_ssh_connect_params(kwds)
     device_handler.add_additional_netconf_params(nc_params)
     session = transport.SSHSession(device_handler)
-    if "hostkey_verify" not in kwds or kwds["hostkey_verify"]:
-        session.load_known_hosts()
 
     try:
        session.connect(*args, **kwds)

--- a/ncclient/transport/ssh.py
+++ b/ncclient/transport/ssh.py
@@ -252,14 +252,17 @@ class SSHSession(Session):
                 username = config.get("user")
             if key_filename is None:
                 key_filename = config.get("identityfile")
-            if hostkey_verify:
-                userknownhostsfile = config.get("userknownhostsfile")
-                if userknownhostsfile:
-                    self.load_known_hosts(os.path.expanduser(userknownhostsfile))
             if timeout is None:
                 timeout = config.get("connecttimeout")
                 if timeout:
                     timeout = int(timeout)
+
+        if hostkey_verify:
+            userknownhostsfile = config.get("userknownhostsfile")
+            if userknownhostsfile:
+                self.load_known_hosts(os.path.expanduser(userknownhostsfile))
+            else:
+                self.load_known_hosts()
 
         if username is None:
             username = getpass.getuser()
@@ -332,10 +335,10 @@ class SSHSession(Session):
         except paramiko.SSHException as e:
             raise SSHError('Negotiation failed: %s' % e)
 
-        server_key_obj = self._transport.get_remote_server_key()
-        fingerprint = _colonify(hexlify(server_key_obj.get_fingerprint()))
-
         if hostkey_verify:
+            server_key_obj = self._transport.get_remote_server_key()
+            fingerprint = _colonify(hexlify(server_key_obj.get_fingerprint()))
+
             is_known_host = False
 
             # For looking up entries for nonstandard (22) ssh ports in known_hosts

--- a/test/unit/test_manager.py
+++ b/test/unit/test_manager.py
@@ -35,7 +35,7 @@ class TestManager(unittest.TestCase):
     def test_connect_ssh1(self, mock_ssh, mock_load_known_hosts):
         manager.connect(host='host')
         mock_ssh.assert_called_once_with(host='host')
-        mock_load_known_hosts.assert_called_once_with()
+        mock_load_known_hosts.assert_not_called()
 
     @patch('socket.socket')
     @patch('paramiko.Transport')


### PR DESCRIPTION
The SSH config option `UserKnownHostsFile`, if set, replaces the default - i.e. either `~/.ssh/known_hosts` should be used, or the file given by the config option, not both; using both might cause bogus `SSHUnknownHostError` exceptions. For this reason, the method `load_known_hosts` should be called only when the value of the option is known.