### PR TITLE
Agent key selection

### DIFF
--- a/ncclient/transport/ssh.py
+++ b/ncclient/transport/ssh.py
@@ -453,7 +453,6 @@ class SSHSession(Session):
                     saved_exception = e
                     self.logger.debug(e)
 
-
         keyfiles = []
         if look_for_keys:
             rsa_key = os.path.expanduser("~/.ssh/id_rsa")

--- a/ncclient/transport/ssh.py
+++ b/ncclient/transport/ssh.py
@@ -427,7 +427,11 @@ class SSHSession(Session):
             agent_keys = paramiko.Agent().get_keys()
             for key_filename in key_filenames:
                 try:
-                    pubkey_filename = key_filename + ".pub"
+                    if key_filename.endswith(".pub"):
+                        pubkey_filename = pukey_filename
+                    else:
+                        pubkey_filename = key_filename + ".pub"
+
                     pubkey_blob=paramiko.PublicBlob.from_file(pubkey_filename)
                     pubkey_fingerprint  = hexlify(md5(pubkey_blob.key_blob).digest())
                     self.logger.debug("Looking for key in SSH agent with fingerprint %s found in filename %s",


### PR DESCRIPTION
OpenSSH restricts the number of authentication retries to 6 i.e. You have 6 attempts in total to login to a remote system within a single TCP connection. This normally isn't a problem when authenticating with passwords or with private key files. A problem does exist when you attempt to authenticate using keys stored in the ssh-agent when the total key count is greater than 6 [ and private key file authentication is not enabled - in which case the number is reduced based on the number of key files specificed ( assuming that these authentications fail ) ] , currently there is no mechanism to select a specific key from the agent.

The merge request offers a simple solution to this problem that doesn't require significant changes to the existing code base - and will work silently with upstream consumers of the library such as ansible as it doesn't require any changes to the external interfaces.

The core of the idea is taken from OpenSSH IdentitiesOnly and IdentityFile directive - this basically allows you to only use specific agent keys based on the list of identities you provide.

The patch takes the list of private keys passed in as existing arguments [ at this point in the code they have already been tried and have either failed because they don't exist, can't be decrypted or simply fail to authenticate ]. The .pub extension is appended to the key filename and this file is parsed with the paramiko public key class , if the parse succeeds the key is then compared with those in the agent  and if a match is found the matched agent key is moved to the top of the list.

In essence the default sequence of keys from the agent is permuted to match the sequence of private key files presented as arguments with any non matching keys retained in there original sequence.

For clarity the private keys don't actually ever get used - they are just pointers to the public key counterparts - consequently the private part does not have to exist in the local filesystem or need to be decrypted [ useful for example when you are running on a remote machine that uses ssh agent forwarding ( but has access to the public keys) ]

Hope this explanation is clear and you find the time to review the patch.
