### PR TITLE
add netconf base namespace to edit-config config element if it is missing

### DIFF
--- a/ncclient/devices/csr.py
+++ b/ncclient/devices/csr.py
@@ -14,6 +14,7 @@ generic information needed for interaction with a Netconf server.
 
 
 from .default import DefaultDeviceHandler
+from warnings import warn
 
 def csr_unknown_host_cb(host, fingerprint):
         #This will ignore the unknown host check when connecting to CSR devices
@@ -25,7 +26,15 @@ class CsrDeviceHandler(DefaultDeviceHandler):
 
     """
     def __init__(self, device_params):
+        warn(
+            'CsrDeviceHandler is deprecated, please use IosxeDeviceHandler',
+            DeprecationWarning,
+            stacklevel=2)
         super(CsrDeviceHandler, self).__init__(device_params)
 
     def add_additional_ssh_connect_params(self, kwargs):
+        warn(
+            'CsrDeviceHandler is deprecated, please use IosxeDeviceHandler',
+            DeprecationWarning,
+            stacklevel=2)
         kwargs['unknown_host_cb'] = csr_unknown_host_cb

--- a/ncclient/devices/default.py
+++ b/ncclient/devices/default.py
@@ -255,6 +255,19 @@ class DefaultDeviceHandler(object):
     def transform_reply(self):
         return False
 
+    def transform_edit_config(self, node):
+        """
+        Hook for working around bugs in devices that cannot deal with
+        standard config payloads for edits. This will be called
+        in EditConfig.request just before the request is submitted,
+        meaning it will get an XML tree rooted at edit-config.
+
+        :param node: the XML tree for edit-config
+
+        :return: either the original XML tree if no changes made or a modified XML tree
+        """
+        return node
+
     def get_xml_parser(self, session):
         """
         vendor can chose which parser to use for RPC reply response.

--- a/ncclient/devices/iosxe.py
+++ b/ncclient/devices/iosxe.py
@@ -43,7 +43,7 @@ class IosxeDeviceHandler(DefaultDeviceHandler):
 
     def transform_edit_config(self, node):
         # find the first node that has the tag "config" with no namespace
-        nodes = node.findall(".//config")
+        nodes = node.findall("./config")
         if len(nodes) == 1:
             logger.debug('IOS XE handler: patching namespace of config element')
             nodes[0].tag = '{%s}%s' % (BASE_NS_1_0, 'config')

--- a/ncclient/devices/iosxe.py
+++ b/ncclient/devices/iosxe.py
@@ -12,13 +12,17 @@ generic information needed for interaction with a Netconf server.
 
 """
 
-
 from .default import DefaultDeviceHandler
 
 from ncclient.operations.third_party.iosxe.rpc import SaveConfig
+from ncclient.xml_ import BASE_NS_1_0
+
+import logging
+logger = logging.getLogger("ncclient.devices.iosxe")
+
 
 def iosxe_unknown_host_cb(host, fingerprint):
-        #This will ignore the unknown host check when connecting to CSR devices
+        # This will ignore the unknown host check when connecting to CSR devices
         return True
 
 class IosxeDeviceHandler(DefaultDeviceHandler):
@@ -36,3 +40,11 @@ class IosxeDeviceHandler(DefaultDeviceHandler):
         
     def add_additional_ssh_connect_params(self, kwargs):
         kwargs['unknown_host_cb'] = iosxe_unknown_host_cb
+
+    def transform_edit_config(self, node):
+        # find the first node that has the tag "config" with no namespace
+        nodes = node.findall(".//config")
+        if len(nodes) == 1:
+            logger.debug('IOS XE handler: patching namespace of config element')
+            nodes[0].tag = '{%s}%s' % (BASE_NS_1_0, 'config')
+        return node

--- a/ncclient/operations/edit.py
+++ b/ncclient/operations/edit.py
@@ -72,6 +72,7 @@ class EditConfig(RPC):
                 sub_ele(node, "url").text = config
             else:
                 raise OperationError("Invalid URL.")
+        node = self._device_handler.transform_edit_config(node)
         return self._request(node)
 
 

--- a/test/unit/devices/test_iosxe.py
+++ b/test/unit/devices/test_iosxe.py
@@ -1,5 +1,17 @@
 import unittest
 from ncclient.devices.iosxe import *
+from ncclient.xml_ import new_ele
+from ncclient.xml_ import qualify
+from ncclient.xml_ import validated_element
+
+
+CFG_BROKEN = """
+<config>
+  <native xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-native">
+    <hostname>tl-einarnn-c8kv</hostname>
+  </native>
+</config>
+"""
 
 
 class TestIosxeDevice(unittest.TestCase):
@@ -20,3 +32,10 @@ class TestIosxeDevice(unittest.TestCase):
 
     def test_csr_unknown_host_cb(self):
         self.assertTrue(iosxe_unknown_host_cb('host', 'fingerprint'))
+
+    def test_iosxe_transform_edit_config(self):
+        node = new_ele("edit-config")
+        node.append(validated_element(CFG_BROKEN, ("config", qualify("config"))))
+        node = self.obj.transform_edit_config(node)
+        config_nodes = node.findall('./config')
+        self.assertTrue(len(config_nodes) == 0)


### PR DESCRIPTION
If a caller providing XML content to an IOS XE device (using `IosxeDeviceHandler`) accidentally omits the base netconf namespace from an `edit-config` request, the `IosxeDeviceHandler` will now automatically add the namespace to the `config` element.
