### PR TITLE
update comment in _parse11

### DIFF
--- a/ncclient/transport/parser.py
+++ b/ncclient/transport/parser.py
@@ -206,7 +206,7 @@ class DefaultXMLParser(object):
                 break
 
             elif re_result.group(1):
-                # we've found a chunk delimiter, and group(2) is the digit
+                # we've found a chunk delimiter, and group(1) is the digit
                 # string that will tell us how many bytes past the end of
                 # where it was found that we need to have available to
                 # save the next chunk off


### PR DESCRIPTION
Here is a modification suggestion for a comment that seems to contain a typo.

The comment refers to the regex pattern defined [here](https://github.com/ncclient/ncclient/blob/master/ncclient/transport/parser.py#L62):
```
RE_NC11_DELIM = re.compile(r'\n(?:#([0-9]+)|(##))\n')
```

The chunk delimiter, which contains digits, is matched by `group(1)`. `group(2)` is for the end delimiter, which doesn't contain any digits.
So the comment should mention `group(1)` instead of `group(2)`.