### PR TITLE
Fix missing timeout in ssh post_connect

### DIFF
--- a/ncclient/transport/session.py
+++ b/ncclient/transport/session.py
@@ -88,7 +88,7 @@ class Session(Thread):
             except Exception as e:
                 self.logger.warning('error dispatching to %r: %r', l, e)
 
-    def _post_connect(self):
+    def _post_connect(self, timeout=60):
         "Greeting stuff"
         init_event = Event()
         error = [None] # so that err_cb can bind error[0]. just how it is.
@@ -107,7 +107,7 @@ class Session(Thread):
         self.logger.debug('starting main loop')
         self.start()
         # we expect server's hello message, if server doesn't responds in 60 seconds raise exception
-        init_event.wait(60)
+        init_event.wait(timeout)
         if not init_event.is_set():
             raise SessionError("Capability exchange timed out")
         # received hello message or an error happened

--- a/ncclient/transport/ssh.py
+++ b/ncclient/transport/ssh.py
@@ -401,7 +401,7 @@ class SSHSession(Session):
                 if not handle_exception:
                     continue
             self._channel_name = self._channel.get_name()
-            self._post_connect()
+            self._post_connect(timeout)
             # for further upcoming RPC responses, vendor can chose their
             # choice of parser. Say DOM or SAX
             self.parser = self._device_handler.get_xml_parser(self)


### PR DESCRIPTION
Addressing https://github.com/ncclient/ncclient/issues/542
Extending https://github.com/ncclient/ncclient/pull/543 in conjunction with https://github.com/CiscoTestAutomation/yang/pull/69

Issue was discovered during the use of yang.connector to connect to a device using netconf, and running into timeout errors. The timeout was not being passed to the connection in ssh.py, and there was no ability to specify a custom timeout in session.py