### PR TITLE
Fix build for Python3.12

### DIFF
--- a/versioneer.py
+++ b/versioneer.py
@@ -339,9 +339,9 @@ def get_config_from_root(root):
     # configparser.NoOptionError (if it lacks "VCS="). See the docstring at
     # the top of versioneer.py for instructions on writing your setup.cfg .
     setup_cfg = os.path.join(root, "setup.cfg")
-    parser = configparser.SafeConfigParser()
+    parser = configparser.ConfigParser()
     with open(setup_cfg, "r") as f:
-        parser.readfp(f)
+        parser.read_file(f)
     VCS = parser.get("versioneer", "VCS")  # mandatory
 
     def get(parser, name):


### PR DESCRIPTION
- SafeConfigParser has been an alias for ConfigParser since Python3.2,
  and will be removed in Python3.12;
- readfp has been an alias for read_file since Python3.2, and will be
  removed in Python3.12.

See python/cpython@296e4efebbd1865153ed3be24887a2af3898a0c4
