### PR TITLE
call_home: timeout as argument (#557)

### DIFF
--- a/ncclient/manager.py
+++ b/ncclient/manager.py
@@ -191,7 +191,7 @@ def call_home(*args, **kwds):
     port = kwds.get("port",4334)
     srv_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     srv_socket.bind((host, port))
-    srv_socket.settimeout(10)
+    srv_socket.settimeout(kwds.get("timeout", 10))
     srv_socket.listen()
 
     sock, remote_host = srv_socket.accept()


### PR DESCRIPTION
Sorry for the big delay. I have added this simple change to solve #557. By default and for backwards compatibility, it uses the same timeout there was before if nothing is specified in `kwargs`.