### PR TITLE
issue 564, accept xml as target

### DIFF
--- a/ncclient/operations/util.py
+++ b/ncclient/operations/util.py
@@ -33,19 +33,22 @@ def one_of(*args):
     raise OperationError("Insufficient parameters")
 
 def datastore_or_url(wha, loc, capcheck=None):
-    node = new_ele(wha)
-    if "://" in loc: # e.g. http://, file://, ftp://
-        if capcheck is not None:
-            capcheck(":url") # url schema check at some point!
-            sub_ele(node, "url").text = loc
-    else:
-        #if loc == 'candidate':
-        #    capcheck(':candidate')
-        #elif loc == 'startup':
-        #    capcheck(':startup')
-        #elif loc == 'running' and wha == 'target':
-        #    capcheck(':writable-running')
-        sub_ele(node, loc)
+    try:
+        node = validated_element(loc)
+    except (XMLError, etree.XMLSyntaxError):
+        node = new_ele(wha)
+        if "://" in loc:  # e.g. http://, file://, ftp://
+            if capcheck is not None:
+                capcheck(":url")  # url schema check at some point!
+                sub_ele(node, "url").text = loc
+        else:
+            # if loc == 'candidate':
+            #    capcheck(':candidate')
+            # elif loc == 'startup':
+            #    capcheck(':startup')
+            # elif loc == 'running' and wha == 'target':
+            #    capcheck(':writable-running')
+            sub_ele(node, loc)
     return node
 
 def build_filter(spec, capcheck=None):


### PR DESCRIPTION
Potential solution to: https://github.com/ncclient/ncclient/issues/564
Perhaps I've oversimplified this but it seems easy enough.

This way target could be specified like below which is correct according to Nokia SROS documentation and comes through correctly in the request.
```
<target>
    <configuration-region xmlns="urn:nokia.com:sros:ns:yang:sr:ietf-netconf-augments">debug</configuration-region>
    <candidate/>
</target>
```

Perhaps if '</' is seen in `loc` and a syntax exception is thrown it should be raised? I'm not sure on convention for this library.