### PR TITLE
Introduce Unix Socket Transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,13 +134,18 @@ To run the same tests locally as are run via GitHub's CI/CD integration with Tra
 1. Install testing dependencies:
 
     ```
-    pip install nose rednose coverage coveralls mock
+    pip install pytest coverage coveralls mock
     ```
 
 1. Finally, run the tests:
 
     ```
-    nosetests test --rednose --verbosity=3
+    pytest test --verbosity=3
+    ```
+    
+    For coverage, showing missing lines do:
+    ```
+    coverage run -m pytest test --verbosity=3 && coverage report -m
     ```
 
 ### Making a Release

--- a/examples/base/nc10.py
+++ b/examples/base/nc10.py
@@ -16,7 +16,7 @@ warnings.simplefilter("ignore", DeprecationWarning)
 from ncclient import manager
 
 def demo(path):
-    with manager.connect_UnixSocket(path) as m:
+    with manager.connect_uds(path) as m:
         for c in m.server_capabilities:
             print(c)
 

--- a/examples/base/nc10.py
+++ b/examples/base/nc10.py
@@ -1,0 +1,24 @@
+#! /usr/bin/env python
+#
+# Connect to NETCONF server using unix socket passed on the command line.
+# Then display the servers capabilities. After connecting you can also use 
+# all other operations supported by ncclient, example: get(), get_config()...
+#
+# To test against a example NETCONF server with unix socket support check out:
+# https://github.com/CESNET/libnetconf2
+# It contains an example server which can listen for connections using a unix 
+# socket.
+#
+# $ ./nc10.py "/path/to/socket"
+
+import sys, warnings
+warnings.simplefilter("ignore", DeprecationWarning)
+from ncclient import manager
+
+def demo(path):
+    with manager.connect_UnixSocket(path) as m:
+        for c in m.server_capabilities:
+            print(c)
+
+if __name__ == '__main__':
+    demo(sys.argv[1])

--- a/ncclient/manager.py
+++ b/ncclient/manager.py
@@ -158,6 +158,19 @@ def connect_tls(*args, **kwargs):
 
     return Manager(session, device_handler, **manager_params)
 
+def connect_UnixSocket(*args, **kwargs):
+    """Initialize a :class:`Manager` over the Unix Socket transport."""
+    device_params = _extract_device_params(kwargs)
+    manager_params = _extract_manager_params(kwargs)
+    nc_params = _extract_nc_params(kwargs)
+
+    device_handler = make_device_handler(device_params)
+    device_handler.add_additional_netconf_params(nc_params)
+    session = transport.UnixSocketSession(device_handler)
+
+    session.connect(*args, **kwargs)
+
+    return Manager(session, device_handler, **manager_params)
 
 def connect_ioproc(*args, **kwds):
     device_params = _extract_device_params(kwds)

--- a/ncclient/manager.py
+++ b/ncclient/manager.py
@@ -158,7 +158,7 @@ def connect_tls(*args, **kwargs):
 
     return Manager(session, device_handler, **manager_params)
 
-def connect_UnixSocket(*args, **kwargs):
+def connect_uds(*args, **kwargs):
     """Initialize a :class:`Manager` over the Unix Socket transport."""
     device_params = _extract_device_params(kwargs)
     manager_params = _extract_manager_params(kwargs)

--- a/ncclient/transport/__init__.py
+++ b/ncclient/transport/__init__.py
@@ -17,6 +17,7 @@
 from ncclient.transport.session import Session, SessionListener, NetconfBase
 from ncclient.transport.ssh import SSHSession
 from ncclient.transport.tls import TLSSession
+from ncclient.transport.unixSocket import UnixSocketSession
 from ncclient.transport.errors import *
 
 __all__ = [
@@ -24,6 +25,7 @@ __all__ = [
     'SessionListener',
     'SSHSession',
     'TLSSession',
+    'UnixSocketSession',
     'TransportError',
     'AuthenticationError',
     'SessionCloseError',

--- a/ncclient/transport/errors.py
+++ b/ncclient/transport/errors.py
@@ -53,3 +53,6 @@ class NetconfFramingError(TransportError):
 
 class TLSError(TransportError):
     pass
+
+class UnixSocketError (TransportError):
+    pass

--- a/ncclient/transport/unixSocket.py
+++ b/ncclient/transport/unixSocket.py
@@ -1,0 +1,89 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import socket
+import sys
+import threading
+
+from socket import AF_UNIX, SOCK_STREAM
+
+if sys.version < '3':
+    from six import StringIO
+else:
+    from io import BytesIO as StringIO
+
+from ncclient.capabilities import Capabilities
+from ncclient.logging_ import SessionLoggerAdapter
+from ncclient.transport.errors import UnixSocketError
+from ncclient.transport.session import Session
+from ncclient.transport.parser import DefaultXMLParser
+
+logger = logging.getLogger("ncclient.transport.unix")
+
+DEFAULT_SOCKET_PATH = "/tmp/socket.sock"
+DEFAULT_TIMEOUT = 120
+
+BUF_SIZE = 4096
+
+class UnixSocketSession(Session):
+
+    "Implements a NETCONF Session over Unix Socket on local machine."
+
+    def __init__(self, device_handler):
+        capabilities = Capabilities(device_handler.get_capabilities())
+        Session.__init__(self, capabilities)
+        self._connected = False
+        self._socket = None
+        self._buffer = StringIO()
+        self._device_handler = device_handler
+        self._message_list = []
+        self._closing = threading.Event()
+        self.parser = DefaultXMLParser(self)
+        self.logger = SessionLoggerAdapter(logger, {'session': self})
+
+    def _dispatch_message(self, raw):
+        self.logger.info("Received message from host")
+        self.logger.debug("Received:\n%s", raw)
+        return super(UnixSocketSession, self)._dispatch_message(raw)
+
+    def close(self):
+        self._closing.set()
+        self._socket.close()
+        self._connected = False
+
+    def connect(self, path=DEFAULT_SOCKET_PATH, timeout=DEFAULT_TIMEOUT):
+        sock = socket.socket(AF_UNIX, SOCK_STREAM)
+        sock.settimeout(timeout)
+
+        try:
+            sock.connect(path)
+        except Exception:
+            raise UnixSocketError("Could not connect to %s" % path)
+
+        self._socket = sock
+        self._connected = True
+        self._post_connect()
+
+    def _transport_read(self):
+        return self._socket.recv(BUF_SIZE)
+
+    def _transport_write(self, data):
+        return self._socket.send(data)
+
+    def _transport_register(self, selector, event):
+        selector.register(self._socket, event)
+
+    def _send_ready(self):
+        # In contrast to Paramiko's `Channel`, pure python sockets do not
+        # expose `send_ready()` function.
+        return True

--- a/ncclient/transport/unixSocket.py
+++ b/ncclient/transport/unixSocket.py
@@ -12,15 +12,10 @@
 
 import logging
 import socket
-import sys
 import threading
+from io import BytesIO as StringIO
 
 from socket import AF_UNIX, SOCK_STREAM
-
-if sys.version < '3':
-    from six import StringIO
-else:
-    from io import BytesIO as StringIO
 
 from ncclient.capabilities import Capabilities
 from ncclient.logging_ import SessionLoggerAdapter
@@ -30,7 +25,6 @@ from ncclient.transport.parser import DefaultXMLParser
 
 logger = logging.getLogger("ncclient.transport.unix")
 
-DEFAULT_SOCKET_PATH = "/tmp/socket.sock"
 DEFAULT_TIMEOUT = 120
 
 BUF_SIZE = 4096
@@ -61,7 +55,7 @@ class UnixSocketSession(Session):
         self._socket.close()
         self._connected = False
 
-    def connect(self, path=DEFAULT_SOCKET_PATH, timeout=DEFAULT_TIMEOUT):
+    def connect(self, path=None, timeout=DEFAULT_TIMEOUT):
         sock = socket.socket(AF_UNIX, SOCK_STREAM)
         sock.settimeout(timeout)
 

--- a/test/unit/transport/test_UnixSocket.py
+++ b/test/unit/transport/test_UnixSocket.py
@@ -1,0 +1,33 @@
+
+import sys
+import unittest
+import socket
+from ncclient.devices.junos import JunosDeviceHandler
+
+try:
+    from unittest.mock import MagicMock, patch, call
+except ImportError:
+    from mock import MagicMock, patch, call
+
+from ncclient.transport.errors import UnixSocketError
+from ncclient.transport.unixSocket import UnixSocketSession
+
+PATH = '/tmp/test_socket.sock'
+
+class TestUnixSocket(unittest.TestCase):
+
+    @patch('socket.socket.close')
+    def test_close_UnixSocket(self, mock_sock_close_fn):
+        session = UnixSocketSession(MagicMock())
+        session._socket = socket.socket()
+        session._connected = True
+        session.close()
+        mock_sock_close_fn.assert_called_once_with()
+        self.assertFalse(session.connected)
+
+    @patch('socket.socket')
+    @patch('ncclient.transport.Session._post_connect')
+    def test_connect_UnixSocket(self, mock_post_connect, mock_socket):
+        session = UnixSocketSession(MagicMock())
+        session.connect(path=PATH)
+        self.assertTrue(session.connected)


### PR DESCRIPTION
Added Unix Socket transport for local communication between ncclient and server.
```
unixSocketconnection = manager.connect_UnixSocket('path to socket', timeout)
```
Enables fast connections between ncclient and local servers and applications such as [clixon](https://github.com/clicon/clixon)'s backend server that uses unix socket rather than ssh.

(I also edited the readme 'for developers' section so that it now says to use pytest rather than nose for testing, #590)