### PR TITLE
feat: Add support for Nokia SR OS private candidate mode

### DIFF
--- a/examples/vendor/nokia/sros/config_mode.py
+++ b/examples/vendor/nokia/sros/config_mode.py
@@ -1,0 +1,118 @@
+import logging
+import sys
+import threading
+import time
+from ncclient import manager
+
+# Device connection details
+DEVICE_HOST = '62.40.111.58'
+DEVICE_PORT = 3830
+DEVICE_USER = 'admin'
+DEVICE_PASS = 'admin'
+
+# Configuration payload template for SNMP community string
+EDIT_CONFIG_PAYLOAD = """
+<config xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
+    <configure xmlns="urn:nokia.com:sros:ns:yang:sr:conf">
+        <system>
+            <security>
+                <snmp>
+                    <community>
+                        <community-string>TestCommunity-{}</community-string>
+                        <access-permissions>r</access-permissions>
+                        <version>v2c</version>
+                    </community>
+                </snmp>
+            </security>
+        </system>
+    </configure>
+</config>
+"""
+
+
+def create_ncclient_session(host, port, username, password, config_mode=None):
+    """
+    Creates and returns an ncclient manager session for connecting to the Nokia SR OS device.
+
+    :param host: Hostname or IP of the Nokia device
+    :param port: NETCONF port
+    :param username: Username for device authentication
+    :param password: Password for device authentication
+    :param config_mode: 'private' to use private candidate mode, None for default mode
+    :return: NETCONF manager session
+    """
+    device_params = {'name': 'sros'}
+    if config_mode:
+        device_params['config_mode'] = config_mode
+
+    return manager.connect(
+        host=host,
+        port=port,
+        username=username,
+        password=password,
+        hostkey_verify=False,
+        device_params=device_params
+    )
+
+
+def configure_and_commit(session_id, config_mode=None):
+    """
+    Creates a NETCONF session, edits the configuration, and commits the changes.
+
+    :param session_id: Unique session identifier for logging
+    :param config_mode: 'private' for private candidate mode, None for default mode
+    """
+    try:
+        with create_ncclient_session(DEVICE_HOST, DEVICE_PORT, DEVICE_USER, DEVICE_PASS, config_mode=config_mode) as nc_session:
+            logging.info(f"Session {session_id} started with config_mode: {config_mode or 'default'}")
+
+            # Edit the device configuration using the payload
+            edit_payload = EDIT_CONFIG_PAYLOAD.format(session_id)
+            nc_session.edit_config(target='candidate', config=edit_payload)
+            logging.info(f"Session {session_id} successfully edited the configuration.")
+
+            # Commit the changes to the device
+            nc_session.commit(comment=f"Session {session_id} commit in {config_mode or 'default'} mode")
+            logging.info(f"Session {session_id} committed successfully in {config_mode or 'default'} mode.")
+
+    except Exception as e:
+        logging.error(f"Session {session_id} encountered an error: {e}")
+
+
+def run_concurrent_sessions(session_ids, config_mode=None):
+    """
+    Runs multiple NETCONF sessions concurrently.
+
+    :param session_ids: List of session IDs to identify different threads
+    :param config_mode: 'private' to use private candidate mode, None for default mode
+    """
+    threads = []
+    for session_id in session_ids:
+        thread = threading.Thread(target=configure_and_commit, args=(session_id, config_mode))
+        threads.append(thread)
+        thread.start()
+
+    # Ensure all threads finish execution
+    for thread in threads:
+        thread.join()
+
+
+def main():
+    LOG_FORMAT = '%(asctime)s %(levelname)s %(filename)s:%(lineno)d %(message)s'
+    logging.basicConfig(stream=sys.stdout, level=logging.INFO, format=LOG_FORMAT)
+
+    logging.info("Starting test with concurrent sessions in default mode (expecting conflicts)...")
+
+    # Run test with concurrent sessions in default mode
+    run_concurrent_sessions([1, 2, 3, 4, 5])
+
+    logging.info("Now testing with concurrent sessions in private mode (no conflicts expected)...")
+
+    # Run test with concurrent sessions in private candidate mode
+    run_concurrent_sessions([6, 7, 8, 9], config_mode='private')
+
+    logging.info("Test completed.")
+
+
+if __name__ == '__main__':
+    main()

--- a/ncclient/devices/sros.py
+++ b/ncclient/devices/sros.py
@@ -1,9 +1,10 @@
-from lxml import etree
-
 from .default import DefaultDeviceHandler
 from ncclient.operations.third_party.sros.rpc import MdCliRawCommand, Commit
 from ncclient.xml_ import BASE_NS_1_0
 
+
+class ConfigMode:
+    PRIVATE = 'private'
 
 def passthrough(xml):
     return xml
@@ -30,7 +31,11 @@ class SrosDeviceHandler(DefaultDeviceHandler):
             'urn:ietf:params:xml:ns:netconf:base:1.0',
             'urn:ietf:params:xml:ns:yang:1',
             'urn:ietf:params:netconf:capability:confirmed-commit:1.1',
-            'urn:ietf:params:netconf:capability:validate:1.1']
+            'urn:ietf:params:netconf:capability:validate:1.1',
+        ]
+        if self.device_params.get('config_mode') == ConfigMode.PRIVATE:
+            additional.append('urn:nokia.com:nc:pc')
+
         return base + additional
 
     def get_xml_base_namespace_dict(self):


### PR DESCRIPTION
**Changes:**

- Enhanced `SrosDeviceHandler` to support "private candidate" mode:
  - Added `urn:nokia.com:nc:pc` client capability when operating in private mode
  - Introduced `config_mode` device parameter to switch between default and private modes
  - Updated `get_capabilities()` to dynamically include private candidate capability
- Added unit tests to validate the behavior of private candidate mode and ensure correct NETCONF session handling

**Reason for Change:**

Nokia SR OS supports "private candidate" mode, allowing multiple concurrent NETCONF sessions to configure different parts of the device without locking conflicts. This is crucial for environments with simultaneous configuration changes, as it prevents locking errors.

We’ve experienced issues with concurrent NETCONF sessions conflicting, causing automation failures and making the process unreliable.

This PR adds support for private candidate mode in ncclient, enabling multiple sessions to run concurrently without conflicts. It will improve automation reliability and allow smoother, more efficient parallel configuration changes.

For more details on private candidate mode, see the [Nokia Private candidates over NETCONF](https://documentation.nokia.com/sr/23-3-1/books/system-management/netconf-system-management-1.html#disjoint-private-candidates-netconf).

**Tests:**
Added unit tests in `test/unit/devices/test_sros.py` to validate the changes.
Ensured that the private candidate mode is activated properly by sending the correct capabilities in the `<hello> ` message.

**Example Usage:**
A new example of how to use the private candidate mode has been added to the Nokia folder under `examples/vendor/nokia/sros/config_mode.py.`