### PR TITLE
Adding error handling parameters for RPC replies.

### DIFF
--- a/examples/vendor/nokia/sros/config_mode.py
+++ b/examples/vendor/nokia/sros/config_mode.py
@@ -5,8 +5,8 @@ import time
 from ncclient import manager
 
 # Device connection details
-DEVICE_HOST = '62.40.111.58'
-DEVICE_PORT = 3830
+DEVICE_HOST = 'localhost'
+DEVICE_PORT = 830
 DEVICE_USER = 'admin'
 DEVICE_PASS = 'admin'
 

--- a/ncclient/devices/alu.py
+++ b/ncclient/devices/alu.py
@@ -23,8 +23,8 @@ class AluDeviceHandler(DefaultDeviceHandler):
     Alcatel-Lucent 7x50 handler for device specific information.
     """
 
-    def __init__(self, device_params):
-        super(AluDeviceHandler, self).__init__(device_params)
+    def __init__(self, device_params, ignore_errors=None):
+        super(AluDeviceHandler, self).__init__(device_params, ignore_errors)
 
     def get_capabilities(self):
         return [

--- a/ncclient/devices/ciena.py
+++ b/ncclient/devices/ciena.py
@@ -7,8 +7,8 @@ class CienaDeviceHandler(DefaultDeviceHandler):
     Ciena handler for device specific information.
     """
 
-    def __init__(self, device_params):
-        super(CienaDeviceHandler, self).__init__(device_params)
+    def __init__(self, device_params, ignore_errors=None):
+        super(CienaDeviceHandler, self).__init__(device_params, ignore_errors)
 
     def get_xml_base_namespace_dict(self):
         return {None: BASE_NS_1_0}

--- a/ncclient/devices/csr.py
+++ b/ncclient/devices/csr.py
@@ -25,12 +25,12 @@ class CsrDeviceHandler(DefaultDeviceHandler):
     Cisco CSR handler for device specific information.
 
     """
-    def __init__(self, device_params):
+    def __init__(self, device_params, ignore_errors=None):
         warn(
             'CsrDeviceHandler is deprecated, please use IosxeDeviceHandler',
             DeprecationWarning,
             stacklevel=2)
-        super(CsrDeviceHandler, self).__init__(device_params)
+        super(CsrDeviceHandler, self).__init__(device_params, ignore_errors)
 
     def add_additional_ssh_connect_params(self, kwargs):
         warn(

--- a/ncclient/devices/default.py
+++ b/ncclient/devices/default.py
@@ -57,9 +57,10 @@ class DefaultDeviceHandler(object):
             "urn:ietf:params:netconf:capability:with-defaults:1.0"
     ]
 
-    def __init__(self, device_params=None):
+    def __init__(self, device_params=None, ignore_errors=None):
         self.device_params = device_params
         self.capabilities = []
+        self._EXEMPT_ERRORS = ignore_errors or self._EXEMPT_ERRORS
         # Turn all exempt errors into lower case, since we don't want those comparisons
         # to be case sensitive later on. Sort them into exact match, wildcard start,
         # wildcard end, and full wildcard categories, depending on whether they start

--- a/ncclient/devices/ericsson.py
+++ b/ncclient/devices/ericsson.py
@@ -23,8 +23,8 @@ class EricssonDeviceHandler(DefaultDeviceHandler):
     """
     _EXEMPT_ERRORS = []
 
-    def __init__(self, device_params):
-        super(EricssonDeviceHandler, self).__init__(device_params)
+    def __init__(self, device_params, ignore_errors=None):
+        super(EricssonDeviceHandler, self).__init__(device_params, ignore_errors)
 
     def get_xml_base_namespace_dict(self):
         return {None: BASE_NS_1_0}

--- a/ncclient/devices/h3c.py
+++ b/ncclient/devices/h3c.py
@@ -29,8 +29,8 @@ class H3cDeviceHandler(DefaultDeviceHandler):
     """
     _EXEMPT_ERRORS = []
 
-    def __init__(self, device_params):
-        super(H3cDeviceHandler, self).__init__(device_params)
+    def __init__(self, device_params, ignore_errors=None):
+        super(H3cDeviceHandler, self).__init__(device_params, ignore_errors)
 
     def add_additional_operations(self):
         dict = {}

--- a/ncclient/devices/hpcomware.py
+++ b/ncclient/devices/hpcomware.py
@@ -4,8 +4,8 @@ from ncclient.operations.third_party.hpcomware.rpc import DisplayCommand, Config
 
 class HpcomwareDeviceHandler(DefaultDeviceHandler):
 
-    def __init__(self, device_params):
-        super(HpcomwareDeviceHandler, self).__init__(device_params)
+    def __init__(self, device_params, ignore_errors=None):
+        super(HpcomwareDeviceHandler, self).__init__(device_params, ignore_errors)
 
     def get_xml_base_namespace_dict(self):
         """

--- a/ncclient/devices/huawei.py
+++ b/ncclient/devices/huawei.py
@@ -30,8 +30,8 @@ class HuaweiDeviceHandler(DefaultDeviceHandler):
     """
     _EXEMPT_ERRORS = []
 
-    def __init__(self, device_params):
-        super(HuaweiDeviceHandler, self).__init__(device_params)
+    def __init__(self, device_params, ignore_errors=None):
+        super(HuaweiDeviceHandler, self).__init__(device_params, ignore_errors)
 
 
     def add_additional_operations(self):

--- a/ncclient/devices/huaweiyang.py
+++ b/ncclient/devices/huaweiyang.py
@@ -28,8 +28,8 @@ class HuaweiyangDeviceHandler(DefaultDeviceHandler):
     """
     _EXEMPT_ERRORS = []
 
-    def __init__(self, device_params):
-        super(HuaweiyangDeviceHandler, self).__init__(device_params)
+    def __init__(self, device_params, ignore_errors=None):
+        super(HuaweiyangDeviceHandler, self).__init__(device_params, ignore_errors)
 
     def get_capabilities(self):
         # Just need to replace a single value in the default capabilities

--- a/ncclient/devices/iosxe.py
+++ b/ncclient/devices/iosxe.py
@@ -30,8 +30,8 @@ class IosxeDeviceHandler(DefaultDeviceHandler):
     Cisco IOS-XE handler for device specific information.
 
     """
-    def __init__(self, device_params):
-        super(IosxeDeviceHandler, self).__init__(device_params)
+    def __init__(self, device_params, ignore_errors=None):
+        super(IosxeDeviceHandler, self).__init__(device_params, ignore_errors)
 
     def add_additional_operations(self):
         dict = {}

--- a/ncclient/devices/iosxr.py
+++ b/ncclient/devices/iosxr.py
@@ -24,8 +24,8 @@ class IosxrDeviceHandler(DefaultDeviceHandler):
     Cisco IOS-XR handler for device specific information.
 
     """
-    def __init__(self, device_params):
-        super(IosxrDeviceHandler, self).__init__(device_params)
+    def __init__(self, device_params, ignore_errors=None):
+        super(IosxrDeviceHandler, self).__init__(device_params, ignore_errors)
 
     def add_additional_ssh_connect_params(self, kwargs):
         kwargs['unknown_host_cb'] = iosxr_unknown_host_cb

--- a/ncclient/devices/junos.py
+++ b/ncclient/devices/junos.py
@@ -37,8 +37,8 @@ class JunosDeviceHandler(DefaultDeviceHandler):
 
     """
 
-    def __init__(self, device_params):
-        super(JunosDeviceHandler, self).__init__(device_params)
+    def __init__(self, device_params, ignore_errors=None):
+        super(JunosDeviceHandler, self).__init__(device_params, ignore_errors)
         self.__reply_parsing_error_transform_by_cls = {
             GetSchemaReply: fix_get_schema_reply
         }

--- a/ncclient/devices/nexus.py
+++ b/ncclient/devices/nexus.py
@@ -35,8 +35,8 @@ class NexusDeviceHandler(DefaultDeviceHandler):
                                             # name for VLAN)
     ]
 
-    def __init__(self, device_params):
-        super(NexusDeviceHandler, self).__init__(device_params)
+    def __init__(self, device_params, ignore_errors=None):
+        super(NexusDeviceHandler, self).__init__(device_params, ignore_errors)
 
     def add_additional_operations(self):
         dict = {}

--- a/ncclient/devices/sros.py
+++ b/ncclient/devices/sros.py
@@ -14,8 +14,8 @@ class SrosDeviceHandler(DefaultDeviceHandler):
     Nokia SR OS handler for device specific information.
     """
 
-    def __init__(self, device_params):
-        super(SrosDeviceHandler, self).__init__(device_params)
+    def __init__(self, device_params, ignore_errors=None):
+        super(SrosDeviceHandler, self).__init__(device_params, ignore_errors)
 
     def get_capabilities(self):
         """Set SR OS device handler client capabilities


### PR DESCRIPTION
This adds ability to dynamicall pass RPC error raise mode and a list of errors (string pattern) to be ignored in RPC replies.

This is more flexible compared to the current method of statically exempting errors within the device handler classes.