### PR TITLE
Drop the pytest-runner dependency

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,3 @@
-pytest-runner
 pytest-cov
 sphinx
 flake8

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
+pytest
 pytest-cov
 sphinx
 flake8


### PR DESCRIPTION
To expand on the rationale for this, `pytest-runner` has been [deprecated upstream](https://github.com/pytest-dev/pytest-runner/tree/v6.0.1?tab=readme-ov-file#deprecation-notice) for some time, and the project is now archived.

It is not required for running the tests via `tox` anyway, so nothing seems to be lost by removing the dependency.