### PR TITLE
Fix exception on ssh connection with passwordless key

### DIFF
--- a/ncclient/transport/ssh.py
+++ b/ncclient/transport/ssh.py
@@ -397,7 +397,9 @@ class SSHSession(Session):
 
         for key_filename in key_filenames:
             try:
-                key = paramiko.PKey.from_path(key_filename, password.encode("utf-8"))
+                if password:
+                    password = password.encode("utf-8")
+                key = paramiko.PKey.from_path(key_filename, password)
                 self.logger.debug("Trying key %s from %s",
                                   hexlify(key.get_fingerprint()),
                                   key_filename)
@@ -467,7 +469,9 @@ class SSHSession(Session):
 
         for filename in keyfiles:
             try:
-                key = paramiko.PKey.from_path(filename, password.encode("utf-8"))
+                if password:
+                    password = password.encode("utf-8")
+                key = paramiko.PKey.from_path(filename, password)
                 self.logger.debug("Trying discovered key %s in %s",
                                   hexlify(key.get_fingerprint()), filename)
                 self._transport.auth_publickey(username, key)


### PR DESCRIPTION
An exception is thrown when trying to connect to a netconf server with a non-password-protected ssh key. This is because we are trying to encode an empty string in UTF-8.
This produces this error log:
Authentication failure: AttributeError("'NoneType' object has no attribute 'encode'") Only encode the password only if it exists.