### PR TITLE
Update tox.ini for test-requirements.txt → requirements-test.txt

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ usedevelop = True
 install_command = pip install {opts} {packages}
 
 deps = -r{toxinidir}/requirements.txt
-       -r{toxinidir}/test-requirements.txt
+       -r{toxinidir}/requirements-test.txt
 commands =
   pytest {posargs}
 
@@ -18,7 +18,7 @@ commands =
   pytest --cov=ncclient
 
 [testenv:docs]
-deps = -r{toxinidir}/test-requirements.txt
+deps = -r{toxinidir}/requirements-test.txt
 commands = sphinx-build -b html docs/source docs/html
 
 [testenv:pep8]


### PR DESCRIPTION
This fixes testing with `tox` after `test-requirements.txt` was renamed to `requirements-test.txt` in a3566423ae005b41c613d75bdc5fe3435872dbcc.