### PR TITLE
Fix connection to Junos with libssh when netconf is disabled

### DIFF
--- a/ncclient/devices/junos.py
+++ b/ncclient/devices/junos.py
@@ -89,10 +89,13 @@ class JunosDeviceHandler(DefaultDeviceHandler):
             return False
 
     def handle_connection_exceptions(self, sshsession):
-        c = sshsession._channel = sshsession._transport.open_channel(
-            kind="session")
-        c.set_name("netconf-command-" + str(sshsession._channel_id))
-        c.exec_command("xml-mode netconf need-trailer")
+        if sshsession.__class__.__name__ == 'SSHSession':
+            c = sshsession._channel = sshsession._transport.open_channel(
+                kind="session")
+            c.set_name("netconf-command-" + str(sshsession._channel_id))
+            c.exec_command("xml-mode netconf need-trailer")
+        elif sshsession.__class__.__name__ == 'LibSSHSession':
+            sshsession._channel.request_exec("xml-mode netconf need-trailer")
         return True
 
     def reply_parsing_error_transform(self, reply_cls):

--- a/ncclient/transport/libssh.py
+++ b/ncclient/transport/libssh.py
@@ -328,9 +328,11 @@ class LibSSHSession(Session):
             self._channel.open_session()
             self._channel.request_subsystem("netconf")
         except LibSSHError as e:
-            raise SSHError(
-                f"Could not open NETCONF session on channel to {host}:{port}"
-            ) from e
+            handle_exception = self._device_handler.handle_connection_exceptions(self)
+            if not handle_exception:
+                raise SSHError(
+                    f"Could not open NETCONF session on channel to {host}:{port}"
+                ) from e
 
         self._receiver_thread = threading.Thread(
             target=self._receiver_loop,


### PR DESCRIPTION
When Junos devices are not configured explicitely to allow netconf, you can't request the netconf subsystem.
You get the following error: `ncclient.transport.errors.SSHError: Could not open NETCONF session on channel to xxxx:xx`

However it is still possible to use SSH with xml-mode command as it was implemented in the paramiko-based SSH handler. I adapted it to be compatible with the LibSSHSession.