### PR TITLE
Make RPCReplyListener creation_lock re-entrant to avoid deadlock

### DIFF
--- a/ncclient/operations/rpc.py
+++ b/ncclient/operations/rpc.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from threading import Event, Lock
+from threading import Event, Lock, RLock
 from uuid import uuid4
 
 from ncclient.xml_ import *
@@ -217,7 +217,9 @@ class RPCReply:
 
 class RPCReplyListener(SessionListener): # internal use
 
-    creation_lock = Lock()
+    # Use a re-entrant lock so nested/recursive attempts to create the listener
+    # (e.g. during teardown while another RPC is in flight) do not deadlock.
+    creation_lock = RLock()
 
     # one instance per session -- maybe there is a better way??
     def __new__(cls, session, device_handler):


### PR DESCRIPTION
**Summary**

Replace RPCReplyListener.creation_lock with threading.RLock so nested listener creation
(e.g., during device close/__del__) doesn’t deadlock when gevent monkey-patches locks.

**Root cause**

A non-reentrant lock guards singleton listener creation. Teardown can initiate another RPC
while the same thread/greenlet still holds the lock, so the second acquire blocks forever
(seen as gevent.thread.BoundedSemaphore.acquire).

**Fix**

Use RLock and document the re-entrancy requirement.

**Tests**

python -m pytest test   # run from repo root (cwd matters for fixtures)
Result: 274 passed, 3 skipped, 3 warnings (deprecations) on Windows/Python 3.12.

**Issue**

Closes #653