### PR TITLE
Preserve RSA-SHA2 host key algorithms for RSA known_hosts entries

### DIFF
--- a/ncclient/transport/ssh.py
+++ b/ncclient/transport/ssh.py
@@ -41,6 +41,7 @@ import logging
 logger = logging.getLogger("ncclient.transport.ssh")
 
 PORT_NETCONF_DEFAULT = 830
+RSA_SHA2_HOST_KEY_ALGORITHMS = ("rsa-sha2-512", "rsa-sha2-256")
 
 BUF_SIZE = 4096
 
@@ -75,6 +76,19 @@ def _colonify(fp):
     for idx in range(2, len(fp), 2):
         finga += ":" + fp[idx:idx+2]
     return finga
+
+
+def _preferred_host_key_algorithms(key_types):
+    preferred_keys = list(key_types)
+    if "ssh-rsa" not in preferred_keys:
+        return preferred_keys
+
+    insert_at = preferred_keys.index("ssh-rsa")
+    for algorithm in RSA_SHA2_HOST_KEY_ALGORITHMS:
+        if algorithm not in preferred_keys:
+            preferred_keys.insert(insert_at, algorithm)
+            insert_at += 1
+    return preferred_keys
 
 
 class SSHSession(Session):
@@ -301,7 +315,9 @@ class SSHSession(Session):
             if not hostkey_obj:
                 # We've tried all known host key types and haven't found a suitable one to use - bail
                 raise SSHError("Couldn't find suitable paramiko key class for host key %s" % hostkey_b64)
-            self._transport._preferred_keys = [hostkey_obj.get_name()]
+            self._transport._preferred_keys = _preferred_host_key_algorithms(
+                [hostkey_obj.get_name()]
+            )
         elif self._host_keys:
             # Else set preferred host keys to those we possess for the host
             # (avoids situation where known_hosts contains a valid key for the host, but that key type is not selected during negotiation)
@@ -309,7 +325,9 @@ class SSHSession(Session):
             host_port = '[%s]:%s' % (host, port)
             known_host_keys_for_this_host.update(self._host_keys.lookup(host_port) or {})
             if known_host_keys_for_this_host:
-                self._transport._preferred_keys = list(known_host_keys_for_this_host)
+                self._transport._preferred_keys = _preferred_host_key_algorithms(
+                    known_host_keys_for_this_host
+                )
 
         # Connect
         try:

--- a/test/unit/transport/test_ssh.py
+++ b/test/unit/transport/test_ssh.py
@@ -350,6 +350,47 @@ class TestSSH(unittest.TestCase):
         hk_inst.load.assert_called_once_with('file_name')
         mock_os.mock_calls == [call('~/.ssh/config'), call('known_hosts_file')]
 
+    @patch('ncclient.transport.ssh.hexlify')
+    @patch('os.path.expanduser')
+    @patch('paramiko.HostKeys')
+    @patch('paramiko.Transport')
+    @patch('ncclient.transport.ssh.SSHSession._post_connect')
+    @patch('ncclient.transport.ssh.SSHSession._auth')
+    def test_ssh_known_hosts_preserves_rsa_sha2_algorithms(
+            self, mock_auth, mock_pc, mock_transport, mock_hk, mock_os,
+            mock_hex):
+        mock_os.return_value = "file_name"
+        hk_inst = MagicMock(check=MagicMock(return_value=True))
+        hk_inst.lookup.side_effect = [
+            {},
+            {"ssh-rsa": MagicMock()},
+        ]
+        mock_hk.return_value = hk_inst
+        device_handler = JunosDeviceHandler({'name': 'junos'})
+        obj = SSHSession(device_handler)
+        obj.connect(host='h', sock=MagicMock())
+        self.assertEqual(
+            mock_transport.return_value._preferred_keys,
+            ["rsa-sha2-512", "rsa-sha2-256", "ssh-rsa"])
+
+    @patch('ncclient.transport.ssh.hexlify')
+    @patch('paramiko.RSAKey')
+    @patch('paramiko.Transport')
+    @patch('ncclient.transport.ssh.SSHSession._post_connect')
+    @patch('ncclient.transport.ssh.SSHSession._auth')
+    def test_ssh_hostkey_b64_preserves_rsa_sha2_algorithms(
+            self, mock_auth, mock_pc, mock_transport, mock_rsa_key, mock_hex):
+        mock_rsa_key.return_value.get_name.return_value = "ssh-rsa"
+        mock_transport.return_value.get_remote_server_key.return_value = (
+            mock_rsa_key.return_value
+        )
+        device_handler = JunosDeviceHandler({'name': 'junos'})
+        obj = SSHSession(device_handler)
+        obj.connect(host='h', sock=MagicMock(), hostkey_b64='AAAA')
+        self.assertEqual(
+            mock_transport.return_value._preferred_keys,
+            ["rsa-sha2-512", "rsa-sha2-256", "ssh-rsa"])
+
     @patch('ncclient.transport.ssh.SSHSession.close')
     @patch('paramiko.channel.Channel.recv')
     @patch('selectors.DefaultSelector.select')


### PR DESCRIPTION
known_hosts stores RSA host keys as ssh-rsa key type, but modern SSH negotiation may use `rsa-sha2-512` or `rsa-sha2-256` with the same RSA key material. 

ncclient currently narrows Paramiko preferred host key algorithms to only the known_hosts key names, which removes RSA-SHA2 aliases and cause negotiation failure before host-key verification.