### PR TITLE
call_home: set SO_REUSEADDR and close the listening socket (#578)

### DIFF
--- a/ncclient/manager.py
+++ b/ncclient/manager.py
@@ -243,13 +243,22 @@ def connect(*args, **kwds):
 
 def call_home(*args, **kwds):
     host = kwds["host"]
-    port = kwds.get("port",4334)
+    port = kwds.get("port", 4334)
     srv_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    srv_socket.bind((host, port))
-    srv_socket.settimeout(kwds.get("timeout", 10))
-    srv_socket.listen()
-
-    sock, remote_host = srv_socket.accept()
+    # Allow the listening port to be re-bound immediately. Without SO_REUSEADDR a
+    # failed call-home attempt (e.g. the server RSTs the connection) can leave the
+    # address in TIME_WAIT/listening state and the next attempt fails with EADDRINUSE.
+    srv_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    try:
+        srv_socket.bind((host, port))
+        srv_socket.settimeout(kwds.get("timeout", 10))
+        srv_socket.listen()
+        sock, remote_host = srv_socket.accept()
+    finally:
+        # The listening socket has served its purpose once a connection has been
+        # accepted (call-home is single-shot). Always close it so a failed attempt
+        # does not leak the bound port and block subsequent retries.
+        srv_socket.close()
     logger.info('Callhome connection initiated from remote host {0}'.format(remote_host))
     kwds['sock'] = sock
     return connect_ssh(*args, **kwds)

--- a/test/unit/test_manager.py
+++ b/test/unit/test_manager.py
@@ -7,6 +7,7 @@ except (ImportError, AttributeError):
 from ncclient import manager
 from ncclient.devices.junos import JunosDeviceHandler
 import logging
+import socket
 
 
 class TestManager(unittest.TestCase):
@@ -359,6 +360,49 @@ class TestManager(unittest.TestCase):
             mock_ssh.assert_called_once_with(host='0.0.0.0',
                                                 port=1234,
                                                 sock=mock_connected_socket)
+
+    @patch('socket.socket')
+    @patch('ncclient.manager.connect_ssh')
+    def test_call_home_sets_reuseaddr_and_closes_listener(self, mock_ssh, mock_socket_open):
+        mock_connected_socket = MagicMock()
+        mock_server_socket = MagicMock()
+        mock_socket_open.return_value = mock_server_socket
+        mock_server_socket.accept.return_value = (mock_connected_socket, 'remote.host')
+
+        with manager.call_home(host='0.0.0.0', port=1234):
+            pass
+
+        mock_server_socket.setsockopt.assert_called_once_with(
+            socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        mock_ssh.assert_called_once_with(host='0.0.0.0', port=1234,
+                                         sock=mock_connected_socket)
+        mock_server_socket.close.assert_called_once()
+
+    @patch('socket.socket')
+    @patch('ncclient.manager.connect_ssh')
+    def test_call_home_closes_listener_when_connect_fails(self, mock_ssh, mock_socket_open):
+        mock_server_socket = MagicMock()
+        mock_socket_open.return_value = mock_server_socket
+        mock_server_socket.accept.return_value = (MagicMock(), 'remote.host')
+        mock_ssh.side_effect = Exception('SSH banner error')
+
+        with self.assertRaises(Exception):
+            manager.call_home(host='0.0.0.0', port=1234)
+
+        mock_server_socket.close.assert_called_once()
+
+    @patch('socket.socket')
+    @patch('ncclient.manager.connect_ssh')
+    def test_call_home_closes_listener_on_accept_timeout(self, mock_ssh, mock_socket_open):
+        mock_server_socket = MagicMock()
+        mock_socket_open.return_value = mock_server_socket
+        mock_server_socket.accept.side_effect = socket.timeout()
+
+        with self.assertRaises(socket.timeout):
+            manager.call_home(host='0.0.0.0', port=1234)
+
+        mock_server_socket.close.assert_called_once()
+        mock_ssh.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

`manager.call_home()` creates its listening socket without `SO_REUSEADDR`
and never closes it once `accept()` returns or if the subsequent SSH
connect fails. When a call-home attempt fails mid-handshake (e.g. the
NETCONF server RSTs the connection, as reported on Windows in #578), the
listening socket stays bound and the next attempt fails with `EADDRINUSE`
(`[Errno 98]` / `WinError 10048`).

## Change

- Set `SO_REUSEADDR` on the listening socket before `bind()`.
- Wrap `bind`/`listen`/`accept` in `try/finally` so the listening socket is
  always closed once it has accepted (or failed to accept) a connection.
  `call_home()` is single-shot, so the listening socket is not needed after
  `accept()`.

Based on the workaround proposed by @sjd-xlnx in #578.

## Tests

Added unit tests covering the success, connect-failure and accept-timeout
paths: `SO_REUSEADDR` is set, and the listening socket is always closed.
Verified on Windows (Python 3.13) and Linux.

Fixes #578
Refs #515