### PR TITLE
Allow configuring paramiko banner_timeout and auth_timeout in SSHSession.connect()

### DIFF
--- a/ncclient/transport/ssh.py
+++ b/ncclient/transport/ssh.py
@@ -165,7 +165,9 @@ class SSHSession(Session):
             bind_addr           = None,
             sock                = None,
             keepalive           = None,
-            environment         = None):
+            environment         = None,
+            banner_timeout      = None,
+            auth_timeout        = None):
 
         """Connect via SSH and initialize the NETCONF session. First attempts the publickey authentication method and then password authentication.
 
@@ -204,6 +206,10 @@ class SSHSession(Session):
         *keepalive* Turn on/off keepalive packets (default is off). If this is set, after interval seconds without sending any data over the connection, a "keepalive" packet will be sent (and ignored by the remote host). This can be useful to keep connections alive over a NAT.
 
         *environment* a dictionary containing the name and respective values to set
+
+        *banner_timeout* is an optional timeout (in seconds) for reading the remote SSH protocol banner. When unset, paramiko's default is used. Raise this for slow devices that intermittently fail with "Error reading SSH protocol banner".
+
+        *auth_timeout* is an optional timeout (in seconds) for the SSH authentication phase. When unset, paramiko's default is used. Raise this for devices with slow authentication backends.
         """
         if not (host or sock_fd or sock):
             raise SSHError("Missing host, socket or socket fd")
@@ -285,6 +291,10 @@ class SSHSession(Session):
             sock.settimeout(timeout)
 
         self._transport = paramiko.Transport(sock)
+        if banner_timeout is not None:
+            self._transport.banner_timeout = banner_timeout
+        if auth_timeout is not None:
+            self._transport.auth_timeout = auth_timeout
         self._transport.set_log_channel(logger.name)
         if config.get("compression") == 'yes':
             self._transport.use_compression()

--- a/test/unit/transport/test_ssh.py
+++ b/test/unit/transport/test_ssh.py
@@ -350,6 +350,33 @@ class TestSSH(unittest.TestCase):
         hk_inst.load.assert_called_once_with('file_name')
         mock_os.mock_calls == [call('~/.ssh/config'), call('known_hosts_file')]
 
+    @patch('paramiko.Transport')
+    @patch('ncclient.transport.ssh.SSHSession._post_connect')
+    @patch('ncclient.transport.ssh.SSHSession._auth')
+    def test_connect_banner_and_auth_timeout(self, mock_auth, mock_pc,
+                                             mock_transport):
+        device_handler = JunosDeviceHandler({'name': 'junos'})
+        obj = SSHSession(device_handler)
+        obj.connect(host='h', sock=MagicMock(), hostkey_verify=False,
+                    banner_timeout=42, auth_timeout=99)
+        self.assertEqual(mock_transport.return_value.banner_timeout, 42)
+        self.assertEqual(mock_transport.return_value.auth_timeout, 99)
+
+    @patch('paramiko.Transport')
+    @patch('ncclient.transport.ssh.SSHSession._post_connect')
+    @patch('ncclient.transport.ssh.SSHSession._auth')
+    def test_connect_timeouts_unset_leaves_paramiko_defaults(
+            self, mock_auth, mock_pc, mock_transport):
+        transport = MagicMock()
+        transport.banner_timeout = 'sentinel-banner'
+        transport.auth_timeout = 'sentinel-auth'
+        mock_transport.return_value = transport
+        device_handler = JunosDeviceHandler({'name': 'junos'})
+        obj = SSHSession(device_handler)
+        obj.connect(host='h', sock=MagicMock(), hostkey_verify=False)
+        self.assertEqual(transport.banner_timeout, 'sentinel-banner')
+        self.assertEqual(transport.auth_timeout, 'sentinel-auth')
+
     @patch('ncclient.transport.ssh.SSHSession.close')
     @patch('paramiko.channel.Channel.recv')
     @patch('selectors.DefaultSelector.select')


### PR DESCRIPTION
ncclient drives paramiko's `Transport` directly and calls `start_client()` without setting `banner_timeout` or `auth_timeout`, so both stay at paramiko's defaults (15s / 30s). `SSHSession.connect()` offers no way to override them — its existing `timeout` argument only reaches `sock.settimeout()`, which does not govern paramiko's banner-read or authentication deadlines.

When a server is slow or under heavy load, the banner read or authentication can exceed those fixed defaults, and paramiko raises `Error reading SSH protocol banner` or an authentication timeout that ncclient surfaces as `SSHError` — with no knob to extend the window.

This adds two optional keyword arguments, `banner_timeout` and `auth_timeout`, applied to the transport before `start_client()`. When unset (`None`), paramiko's defaults are preserved, so the change is fully backward compatible, and both pass through `manager.connect()` automatically.

`auth_timeout` also resolves the long-standing request in #472.

Tests: two unit tests — one asserting the values are set on the transport, one asserting that leaving them unset does not touch paramiko's defaults.

Note: I kept the aligned-`=` style consistent with the existing `connect()` signature block, and left `Changelog` untouched since it appears not to have been updated since 0.6.11 — happy to add an entry if you prefer.

closes #472
